### PR TITLE
IN operator

### DIFF
--- a/src/tink/sql/Expr.hx
+++ b/src/tink/sql/Expr.hx
@@ -8,6 +8,7 @@ enum ExprData<T> {
   EBinOp<A, B, Ret>(op:BinOp<A, B, Ret>, a:Expr<A>, b:Expr<B>):ExprData<Ret>;
   EField(table:String, name:String):ExprData<T>;
   EConst<T>(value:T):ExprData<T>;
+  EArray<T>(value:Array<T>):ExprData<Array<T>>;
 }
 
 @:notNull abstract Expr<T>(ExprData<T>) {
@@ -132,8 +133,15 @@ enum ExprData<T> {
       
   //} endregion  
   
+  // @:op(a in b) // https://github.com/HaxeFoundation/haxe/issues/6224
+  public function inArray<T>(b:Expr<Array<T>>):Condition
+    return EBinOp(In, this, b);
+  
   public function like(b:Expr<String>):Condition
     return EBinOp(Like, this, b);
+  
+  @:from static function ofArray<T>(v:Array<T>):Expr<Array<T>>
+    return EArray(v);
   
   @:from static function ofBool(b:Bool):Condition 
     return EConst(b);
@@ -155,6 +163,7 @@ enum BinOp<A, B, Ret> {
   And:BinOp<Bool, Bool, Bool>;
   Or:BinOp<Bool, Bool, Bool>;
   Like<T:String>:BinOp<T, T, Bool>;
+  In<T>:BinOp<T, Array<T>, Bool>;
 }
 
 enum UnOp<A, Ret> {

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -23,6 +23,7 @@ class Format {
       case Equals: '=';
       case Greater: '>';
       case Like: 'LIKE';
+      case In: 'IN';
     }
     
   static function unOp(o:UnOp<Dynamic, Dynamic>)
@@ -44,6 +45,8 @@ class Format {
             s.ident(table) + '.' + s.ident(name);
           case EConst(value):          
             s.value(value);
+          case EArray(value):          
+            '(${value.map(s.value).join(', ')})';
         }
       
     return rec(e);

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -34,7 +34,7 @@ class Format {
   
   static public function expr<A>(e:Expr<A>, s:Sanitizer):String {
     
-    function isEmptyArray(e:ExprData<Dynamic>)
+    inline function isEmptyArray(e:ExprData<Dynamic>)
       return e.match(EArray([]));
     
     function rec(e:ExprData<Dynamic>)
@@ -42,7 +42,7 @@ class Format {
         switch e {
           case EUnOp(op, a):
             unOp(op) + ' ' + rec(a);
-          case EBinOp(In, a, b) if(isEmptyArray(b)):
+          case EBinOp(In, a, b) if(isEmptyArray(b)): // workaround haxe's weird behavior with abstract over enum
             'false';
           case EBinOp(op, a, b):
             '(${rec(a)} ${binOp(op)} ${rec(b)})';

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -34,11 +34,16 @@ class Format {
   
   static public function expr<A>(e:Expr<A>, s:Sanitizer):String {
     
+    function isEmptyArray(e:ExprData<Dynamic>)
+      return e.match(EArray([]));
+    
     function rec(e:ExprData<Dynamic>)
       return
         switch e {
           case EUnOp(op, a):
             unOp(op) + ' ' + rec(a);
+          case EBinOp(In, a, b) if(isEmptyArray(b)):
+            'false';
           case EBinOp(op, a, b):
             '(${rec(a)} ${binOp(op)} ${rec(b)})';
           case EField(table, name):

--- a/tests/FormatTest.hx
+++ b/tests/FormatTest.hx
@@ -33,6 +33,12 @@ class FormatTest {
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`text` LIKE \'mystring\')');
 	}
 	
+	@:describe('in')
+	public function inArray() {
+		var dataset = db.Types.where(Types.int.inArray([1, 2, 3]));
+		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`int` IN (1, 2, 3))');
+	}
+	
 	// https://github.com/haxetink/tink_sql/issues/10
 	// public function compareNull() {
 	// 	var dataset = db.Types.where(Types.optionalInt == null);

--- a/tests/FormatTest.hx
+++ b/tests/FormatTest.hx
@@ -33,10 +33,14 @@ class FormatTest {
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`text` LIKE \'mystring\')');
 	}
 	
-	@:describe('in')
 	public function inArray() {
 		var dataset = db.Types.where(Types.int.inArray([1, 2, 3]));
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`int` IN (1, 2, 3))');
+	}
+	
+	public function inEmptyArray() {
+		var dataset = db.Types.where(Types.int.inArray([]));
+		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE false');
 	}
 	
 	// https://github.com/haxetink/tink_sql/issues/10


### PR DESCRIPTION
This adds the IN operator e.g. `WHERE field IN (1, 2, 3)`.
Usage: `.where(Table.field.inArray([...]))`

But there is one problem, if the given array is empty, the generated syntax would be invalid (`WHERE field IN ()`). In that case I simply make it write `WHERE false`.