### PR TITLE
Descriptive error message for database properties with missing metadata

### DIFF
--- a/src/tink/sql/macros/DatabaseBuilder.hx
+++ b/src/tink/sql/macros/DatabaseBuilder.hx
@@ -31,7 +31,7 @@ class DatabaseBuilder {
     for (m in c) if(!m.isStatic) {
       var table = 
         switch (m:Field).meta.getValues(':table') {
-          case []: null;
+          case []: m.pos.error('Expected @:table metadata for property ${m.name}');
           case [[]]: m.name;
           case [[v]]: v.getName().sure();
           default: m.pos.error('Invalid use of @:table');

--- a/src/tink/sql/macros/DatabaseBuilder.hx
+++ b/src/tink/sql/macros/DatabaseBuilder.hx
@@ -31,7 +31,7 @@ class DatabaseBuilder {
     for (m in c) if(!m.isStatic) {
       var table = 
         switch (m:Field).meta.getValues(':table') {
-          case []: m.pos.error('Expected @:table metadata for property ${m.name}');
+          case []: continue;
           case [[]]: m.name;
           case [[v]]: v.getName().sure();
           default: m.pos.error('Invalid use of @:table');


### PR DESCRIPTION
Fixes #28. If however other fields should be allowed on the database class this needs to be handled differently.