### PR TITLE
Add explicit TEXT types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,26 @@ Tink SQL has been built to embrace using SQL for your database interactions, but
 Define a database like so:
 
 ```haxe
-import tink.sql.types.*;
+import tink.sql.Types;
 
 typedef User = {
   id:Id<User>,
-  name:Text<255>,
-  @:unique email:Text<255>,
-  password:Text<255>,
+  name:VarChar<255>,
+  @:unique email:VarChar<255>,
+  password:VarChar<255>,
 }
 
 typedef Post = {
   id:Id<Post>,
   author:Id<User>,
-  title:Text.LongText,
-  url:Text<255>,
+  title:LongText,
+  url:VarChar<255>,
 }
 
 typedef Tag = {
   id:Id<Tag>,
-  name:Text<20>,
-  desc:Null<Text.DefaultText>,
+  name:VarChar<20>,
+  desc:Null<DefaultText>,
 }
 
 typedef PostTags = {

--- a/README.md
+++ b/README.md
@@ -11,31 +11,33 @@ Most developers tend to dislike SQL, at least for a significant part of their ca
 
 Relational databases are however a very powerful concept, that was pioneered over 40 years ago.
 
+Tink SQL has been built to embrace using SQL for your database interactions, but in a type safe way that fits with the Haxe ecosystem.
 
+## Defining your schema
 
 Define a database like so:
-  
+
 ```haxe
-import tink.sql.*;
+import tink.sql.types.*;
 
 typedef User = {
   id:Id<User>,
-  name:String,
-  email:String,
-  password:String,
+  name:Text<255>,
+  @:unique email:Text<255>,
+  password:Text<255>,
 }
 
 typedef Post = {
   id:Id<Post>,
   author:Id<User>,
-  title:String,
-  url:String,
+  title:Text.LongText,
+  url:Text<255>,
 }
 
 typedef Tag = {
   id:Id<Tag>,
-  name:String,
-  desc:Null<String>,
+  name:Text<20>,
+  desc:Null<Text.DefaultText>,
 }
 
 typedef PostTags = {
@@ -43,12 +45,44 @@ typedef PostTags = {
   tag:Id<Tag>,
 }
 
-class BlogDb extends tink.sql.Database {
-  @:table var user:User;
-  @:table var post:Post;
-  @:table var tag:Tag;
-  @:table var postTags:PostTags;
-}
+@:tables(User, Post, Tag, PostTags)
+class BlogDb extends tink.sql.Database {}
 ```
+
+## Connecting to the database
+
+```haxe
+import tink.sql.drivers.MySql;
+
+var driver = new tink.sql.drivers.MySql({
+  user: 'user',
+  password: 'pass'
+});
+var db = new Db('db_name', driver);
+```
+
+## Tables API
+
+
+ - Table setup
+    - `db.User.create(): Promise<Noise>;`
+    - `db.User.drop(): Promise<Noise>;`
+ - Selecting
+    - `db.User.count(): Promise<Int>;`
+    - `db.User.all(limit, orderBy): Promise<Array<User>>;`
+    - `db.User.first(orderBy): Promise<User>;`
+    - `db.User.where(filter)`
+ - Writing
+    - `db.User.insertOne(row: User): Promise<Id<User>>;`
+    - `db.User.insertMany(rows: Array<User>): Promise<Id<User>>;`
+    - `db.User.update(f:Fields->Update<Row>, options:{ where: Filter, ?max:Int }): Promise<{rowsAffected: Int}>;`
+        - Example, rename all users called 'Dave' to 'Donald': `db.User.update(function (u) return [u.name.set('Donald')], { where: function (u) return u.name == 'Dave' } );`
+    - `db.User.delete(options:{ where: Filter, ?max:Int }): Promise<{rowsAffected: Int}>;`
+ - Advanced Selecting
+    - `db.User.as(alias);`
+    - `db.User.join(db.User).on(id == copiedFrom).all();`
+    - `db.User.leftJoin(db.User);`
+    - `db.User.rightJoin(db.User);`
+    - `db.User.stream(limit, orderBy): tink.streams.RealStream<User>;`
 
 ... to be continued ...

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ typedef Post = {
 typedef Tag = {
   id:Id<Tag>,
   name:VarChar<20>,
-  desc:Null<DefaultText>,
+  desc:Null<Text>,
 }
 
 typedef PostTags = {

--- a/haxe_libraries/tink_core.hxml
+++ b/haxe_libraries/tink_core.hxml
@@ -1,3 +1,3 @@
-# @install: lix --silent download "https://github.com/haxetink/tink_core/archive/d9cfcee7b24c05eb18cafb72452ea460a3f5b40a.tar.gz" into tink_core/1.15.0/github/d9cfcee7b24c05eb18cafb72452ea460a3f5b40a
--D tink_core=1.15.0
--cp ${HAXESHIM_LIBCACHE}/tink_core/1.15.0/github/d9cfcee7b24c05eb18cafb72452ea460a3f5b40a/src
+# @install: lix --silent download "haxelib:tink_core#1.16.1" into tink_core/1.16.1/haxelib
+-D tink_core=1.16.1
+-cp ${HAXESHIM_LIBCACHE}/tink_core/1.16.1/haxelib/src

--- a/src/tink/sql/Connection.hx
+++ b/src/tink/sql/Connection.hx
@@ -3,7 +3,7 @@ package tink.sql;
 import haxe.DynamicAccess;
 import tink.sql.Expr;
 import tink.sql.Dataset;
-import tink.sql.types.Id;
+import tink.sql.Types;
 import tink.streams.RealStream;
 import tink.sql.Info;
 import tink.sql.Projection;
@@ -12,7 +12,7 @@ import tink.sql.Schema;
 using tink.CoreApi;
 
 interface Connection<Db> {
-  
+
   //function selectProjection<A, Res>(t:Dataset<A, Db>, ?c:Condition, p:Projection<Res>):Stream<A>;
   function dropTable<Row:{}>(table:TableInfo<Row>):Promise<Noise>;
   function createTable<Row:{}>(table:TableInfo<Row>):Promise<Noise>;
@@ -28,11 +28,11 @@ interface Connection<Db> {
 typedef Update<Row> = Array<FieldUpdate<Row>>;
 
 class FieldUpdate<Row> {
-  
+
   public var field(default, null):Field<Row, Dynamic>;
   public var expr(default, null):Expr<Dynamic>;
-  
-  public function new<A>(field:Field<Row, A>, expr:Expr<A>) {  
+
+  public function new<A>(field:Field<Row, A>, expr:Expr<A>) {
     this.field = field;
     this.expr = expr;
   }

--- a/src/tink/sql/Expr.hx
+++ b/src/tink/sql/Expr.hx
@@ -2,7 +2,7 @@ package tink.sql;
 
 import haxe.io.Bytes;
 import geojson.*;
-import tink.sql.types.*;
+import tink.sql.Types;
 import tink.sql.Connection.FieldUpdate;
 
 typedef Condition = Expr<Bool>;
@@ -28,204 +28,204 @@ enum ValueType<T> {
 }
 
 @:notNull abstract Expr<T>(ExprData<T>) {
-  
+
   inline function new(e) this = e;
-  
-  @:from static function ofData<T>(d:ExprData<T>) 
+
+  @:from static function ofData<T>(d:ExprData<T>)
     return new Expr(d);
-  
+
   public var data(get, never):ExprData<T>;
-  
+
     @:to inline function get_data()
       return this;
-      
+
   //{ region arithmetics
     @:op(a + b) static function add<T:Float>(a:Expr<T>, b:Expr<T>):Expr<T>
       return EBinOp(Add, a, b);
-      
+
     @:op(a - b) static function subt<T:Float>(a:Expr<T>, b:Expr<T>):Expr<T>
       return EBinOp(Subt, a, b);
-      
+
     @:op(a * b) static function mult<T:Float>(a:Expr<T>, b:Expr<T>):Expr<T>
       return EBinOp(Mult, a, b);
-      
+
     @:op(a / b) static function div<T:Float>(a:Expr<T>, b:Expr<T>):Expr<Float>
       return EBinOp(Div, a, b);
-      
+
     @:op(a % b) static function mod<T:Float>(a:Expr<T>, b:Expr<T>):Expr<T>
       return EBinOp(Mod, a, b);
-  //} endregion  
-    
+  //} endregion
+
   //{ region relations
     @:op(a == b) static function eq<T>(a:Expr<T>, b:Expr<T>):Condition
       return EBinOp(Equals, a, b);
-    
+
     @:op(a != b) static function neq<T>(a:Expr<T>, b:Expr<T>):Condition
       return not(a == b);
-      
+
     @:op(a > b) static function gt<T:Float>(a:Expr<T>, b:Expr<T>):Condition
-      return EBinOp(Greater, a, b); 
-      
+      return EBinOp(Greater, a, b);
+
     @:op(a < b) static function lt<T:Float>(a:Expr<T>, b:Expr<T>):Condition
-      return EBinOp(Greater, b, a); 
-      
+      return EBinOp(Greater, b, a);
+
     @:op(a >= b) static function gte<T:Float>(a:Expr<T>, b:Expr<T>):Condition
-      return not(EBinOp(Greater, b, a)); 
-      
+      return not(EBinOp(Greater, b, a));
+
     @:op(a <= b) static function lte<T:Float>(a:Expr<T>, b:Expr<T>):Condition
-      return not(EBinOp(Greater, a, b));   
-      
+      return not(EBinOp(Greater, a, b));
+
     @:op(a > b) static function gtDate(a:Expr<Date>, b:Expr<Date>):Condition
-      return EBinOp(Greater, a, b); 
-      
+      return EBinOp(Greater, a, b);
+
     @:op(a < b) static function ltDate(a:Expr<Date>, b:Expr<Date>):Condition
-      return EBinOp(Greater, b, a); 
-      
+      return EBinOp(Greater, b, a);
+
     @:op(a >= b) static function gteDate(a:Expr<Date>, b:Expr<Date>):Condition
-      return not(EBinOp(Greater, b, a)); 
-      
+      return not(EBinOp(Greater, b, a));
+
     @:op(a <= b) static function lteDate(a:Expr<Date>, b:Expr<Date>):Condition
-      return not(EBinOp(Greater, a, b));   
-  //} endregion  
-    
+      return not(EBinOp(Greater, a, b));
+  //} endregion
+
   //{ region arithmetics for constants
     @:commutative
     @:op(a + b) static function addConst<T:Float>(a:Expr<T>, b:T):Expr<T>
       return add(a, EValue(b, cast VFloat));
-      
+
     @:op(a - b) static function subtByConst<T:Float>(a:Expr<T>, b:T):Expr<T>
       return subt(a, EValue(b, cast VFloat));
-      
+
     @:op(a - b) static function subtConst<T:Float>(a:T, b:Expr<T>):Expr<T>
       return subt(EValue(a, cast VFloat), b);
-    
+
     @:commutative
     @:op(a * b) static function multConst<T:Float>(a:Expr<T>, b:T):Expr<T>
       return mult(a, EValue(b, cast VFloat));
-      
+
     @:op(a / b) static function divByConst<T:Float>(a:Expr<T>, b:T):Expr<Float>
       return div(a, EValue(b, cast VFloat));
-      
+
     @:op(a / b) static function divConst<T:Float>(a:T, b:Expr<T>):Expr<Float>
       return div(EValue(a, cast VFloat), b);
-      
+
     @:op(a % b) static function modByConst<T:Float>(a:Expr<T>, b:T):Expr<T>
       return mod(a, EValue(b, cast VFloat));
-      
+
     @:op(a % b) static function modConst<T:Float>(a:T, b:Expr<T>):Expr<T>
-      return mod(EValue(a, cast VFloat), b);  
+      return mod(EValue(a, cast VFloat), b);
   //} endregion
-    
+
   //{ region relations for constants
-    @:commutative  
+    @:commutative
     @:op(a == b) static function eqBool(a:Expr<Bool>, b:Bool):Condition
-      return eq(a, EValue(b, VBool)); 
-    
+      return eq(a, EValue(b, VBool));
+
     @:commutative
     @:op(a != b) static function neqBool(a:Expr<Bool>, b:Bool):Condition
-      return neq(a, EValue(b, VBool)); 
-         
-    @:commutative  
+      return neq(a, EValue(b, VBool));
+
+    @:commutative
     @:op(a == b) static function eqString(a:Expr<String>, b:String):Condition
-      return eq(a, EValue(b, VString)); 
-    
+      return eq(a, EValue(b, VString));
+
     @:commutative
     @:op(a != b) static function neqString(a:Expr<String>, b:String):Condition
-      return neq(a, EValue(b, VString));   
-      
-    @:commutative  
+      return neq(a, EValue(b, VString));
+
+    @:commutative
     @:op(a == b) static function eqFloat<T:Float>(a:Expr<T>, b:T):Condition
-      return eq(a, EValue(b, cast VFloat)); 
-    
+      return eq(a, EValue(b, cast VFloat));
+
     @:commutative
     @:op(a != b) static function neqFloat<T:Float>(a:Expr<T>, b:T):Condition
-      return neq(a, EValue(b, cast VFloat));      
-        
+      return neq(a, EValue(b, cast VFloat));
+
     @:op(a > b) static function gtConst<T:Float>(a:Expr<T>, b:T):Condition
-      return gt(a, EValue(b, cast VFloat)); 
-      
+      return gt(a, EValue(b, cast VFloat));
+
     @:op(a < b) static function ltConst<T:Float>(a:Expr<T>, b:T):Condition
-      return lt(a, EValue(b, cast VFloat)); 
-      
+      return lt(a, EValue(b, cast VFloat));
+
     @:op(a >= b) static function gteConst<T:Float>(a:Expr<T>, b:T):Condition
-      return gte(a, EValue(b, cast VFloat)); 
-      
+      return gte(a, EValue(b, cast VFloat));
+
     @:op(a <= b) static function lteConst<T:Float>(a:Expr<T>, b:T):Condition
-      return lte(a, EValue(b, cast VFloat));   
-        
+      return lte(a, EValue(b, cast VFloat));
+
     @:op(a > b) static function gtDateConst(a:Expr<Date>, b:Date):Condition
-      return gtDate(a, EValue(b, VDate)); 
-      
+      return gtDate(a, EValue(b, VDate));
+
     @:op(a < b) static function ltDateConst(a:Expr<Date>, b:Date):Condition
-      return ltDate(a, EValue(b, VDate)); 
-      
+      return ltDate(a, EValue(b, VDate));
+
     @:op(a >= b) static function gteDateConst(a:Expr<Date>, b:Date):Condition
-      return gteDate(a, EValue(b, VDate)); 
-      
+      return gteDate(a, EValue(b, VDate));
+
     @:op(a <= b) static function lteDateConst(a:Expr<Date>, b:Date):Condition
-      return lteDate(a, EValue(b, VDate));   
-  //} endregion  
-     
+      return lteDate(a, EValue(b, VDate));
+  //} endregion
+
   //{ region logic
-    @:op(!a) static function not(c:Condition):Condition 
+    @:op(!a) static function not(c:Condition):Condition
       return EUnOp(Not, c, false);
-      
+
     @:op(a && b) static function and(a:Condition, b:Condition):Condition
-      return 
+      return
         switch [a.data, b.data] {
           case [null, _]: b;
           case [_, null]: a;
-          default: EBinOp(And, a, b);    
+          default: EBinOp(And, a, b);
         }
-      
+
     @:op(a || b) static function or(a:Condition, b:Condition):Condition
-      return EBinOp(Or, a, b);  
-      
+      return EBinOp(Or, a, b);
+
     @:op(a || b) static function constOr(a:Bool, b:Condition):Condition
-      return EBinOp(Or, EValue(a, VBool), b);  
-      
+      return EBinOp(Or, EValue(a, VBool), b);
+
     @:op(a || b) static function orConst(a:Condition, b:Bool):Condition
-      return EBinOp(Or, a, EValue(b, VBool)); 
-      
-  //} endregion  
-  
+      return EBinOp(Or, a, EValue(b, VBool));
+
+  //} endregion
+
   public function isNull<T>():Condition
     return EUnOp(IsNull, this, true);
-  
+
   // @:op(a in b) // https://github.com/HaxeFoundation/haxe/issues/6224
   public function inArray<T>(b:Expr<Array<T>>):Condition
     return EBinOp(In, this, b);
-  
+
   public function like(b:Expr<String>):Condition
     return EBinOp(Like, this, b);
-  
+
   @:from static function ofIdArray<T>(v:Array<Id<T>>):Expr<Array<Id<T>>>
     return EValue(v, cast VArray(VInt));
-  
+
   @:from static function ofIntArray<T:Int>(v:Array<T>):Expr<Array<T>>
     return EValue(v, VArray(cast VInt));
-  
+
   @:from static function ofFloatArray<T:Float>(v:Array<T>):Expr<Array<T>>
     return EValue(v, VArray(cast VFloat));
-  
+
   @:from static function ofStringArray<T:String>(v:Array<T>):Expr<Array<T>>
     return EValue(v, VArray(cast VString));
-  
+
   @:from static function ofBool<S:Bool>(b:S):Expr<S>
     return cast EValue(b, cast VBool);
-    
+
   @:from static function ofDate<S:Date>(s:S):Expr<S>
     return EValue(s, cast VDate);
-    
+
   @:from static function ofString<S:String>(s:S):Expr<S>
     return EValue(s, cast VString);
-    
+
   @:from static function ofInt(s:Int):Expr<Int>
     return EValue(s, VInt);
-    
+
   @:from static function ofFloat(s:Float):Expr<Float>
     return EValue(s, VFloat);
-    
+
   @:from static function ofPoint(p:Point):Expr<Point>
     return EValue(p, VGeometry(Point));
 
@@ -234,13 +234,13 @@ enum ValueType<T> {
 class Functions {
   public static function iif<T>(cond:Expr<Bool>, ifTrue:Expr<T>, ifFalse:Expr<T>):Expr<T>
     return ECall('IF', [cast cond, cast ifTrue, cast ifFalse]);
-    
+
   public static function stContains<T>(g1:Expr<Geometry>, g2:Expr<Geometry>):Expr<Bool>
     return ECall('ST_Contains', cast [g1, g2]);
-    
+
   public static function stWithin<T>(g1:Expr<Geometry>, g2:Expr<Geometry>):Expr<Bool>
     return ECall('ST_Within', cast [g1, g2]);
-    
+
   public static function stDistanceSphere(g1:Expr<Point>, g2:Expr<Point>):Expr<Float>
     return ECall('ST_Distance_Sphere', cast [g1, g2]);
 }
@@ -251,7 +251,7 @@ enum BinOp<A, B, Ret> {
   Mult<T:Float>:BinOp<T, T, T>;
   Mod<T:Float>:BinOp<T, T, T>;
   Div<T:Float>:BinOp<T, T, Float>;
-  
+
   Greater<T>:BinOp<T, T, Bool>;
   Equals<T>:BinOp<T, T, Bool>;
   And:BinOp<Bool, Bool, Bool>;
@@ -269,163 +269,163 @@ enum UnOp<A, Ret> {
 @:forward
 abstract Field<Data, Owner>(Expr<Data>) to Expr<Data> {
   public var name(get, never):String;
-  
-    function get_name() 
+
+    function get_name()
       return switch this.data {
         case EField(_, v): v;
         case v: throw 'assert: invalid field $v';
       }
-      
+
   public var table(get, never):String;
-  
-    function get_table() 
+
+    function get_table()
       return switch this.data {
         case EField(v, _): v;
         case v: throw 'assert: invalid field $v';
-      }   
-      
+      }
+
   public function set(e:Expr<Data>):FieldUpdate<Owner>
     return new FieldUpdate(cast this, e);
-      
+
   public inline function new(table, name)
     this = EField(table, name);
   //TODO: it feels pretty sad to have to do this below:
   //{ region arithmetics
     @:op(a + b) static function add<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Expr<T>
       return EBinOp(Add, a, b);
-      
+
     @:op(a - b) static function subt<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Expr<T>
       return EBinOp(Subt, a, b);
-      
+
     @:op(a * b) static function mult<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Expr<T>
       return EBinOp(Mult, a, b);
-      
+
     @:op(a / b) static function div<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Expr<Float>
       return EBinOp(Div, a, b);
-      
+
     @:op(a % b) static function mod<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Expr<T>
       return EBinOp(Mod, a, b);
-  //} endregion  
-    
+  //} endregion
+
   //{ region relations
     @:op(a == b) static function eq<T, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
       return EBinOp(Equals, a, b);
-    
+
     @:op(a != b) static function neq<T, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
       return !(a == b);
-      
+
     @:op(a > b) static function gt<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
-      return EBinOp(Greater, a, b); 
-      
+      return EBinOp(Greater, a, b);
+
     @:op(a < b) static function lt<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
-      return EBinOp(Greater, b, a); 
-      
+      return EBinOp(Greater, b, a);
+
     @:op(a >= b) static function gte<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
-      return !(b > a); 
-      
+      return !(b > a);
+
     @:op(a <= b) static function lte<T:Float, X, Y>(a:Field<T, X>, b:Field<T, Y>):Condition
-      return !(a > b);   
-      
+      return !(a > b);
+
     @:op(a > b) static function gtDate<X, Y>(a:Field<Date, X>, b:Field<Date, Y>):Condition
-      return EBinOp(Greater, a, b); 
-      
+      return EBinOp(Greater, a, b);
+
     @:op(a < b) static function ltDate<X, Y>(a:Field<Date, X>, b:Field<Date, Y>):Condition
-      return EBinOp(Greater, b, a); 
-      
+      return EBinOp(Greater, b, a);
+
     @:op(a >= b) static function gteDate<X, Y>(a:Field<Date, X>, b:Field<Date, Y>):Condition
-      return !(b > a); 
-      
+      return !(b > a);
+
     @:op(a <= b) static function lteDate<X, Y>(a:Field<Date, X>, b:Field<Date, Y>):Condition
-      return !(a > b);   
-  //} endregion  
-    
+      return !(a > b);
+  //} endregion
+
   //{ region arithmetics for constants
     @:commutative
     @:op(a + b) static function addConst<T:Float, S>(a:Field<T, S>, b:T):Expr<T>
       return (a:Expr<T>) + EValue(b, cast VFloat);
-      
+
     @:op(a - b) static function subtByConst<T:Float, S>(a:Field<T, S>, b:T):Expr<T>
       return (a:Expr<T>) - EValue(b, cast VFloat);
-      
+
     @:op(a - b) static function subtConst<T:Float, S>(a:T, b:Field<T, S>):Expr<T>
       return EValue(a, cast VFloat) - (b:Expr<T>);
-    
+
     @:commutative
     @:op(a * b) static function multConst<T:Float, S>(a:Field<T, S>, b:T):Expr<T>
       return (a:Expr<T>) * EValue(b, cast VFloat);
-      
+
     @:op(a / b) static function divByConst<T:Float, S>(a:Field<T, S>, b:T):Expr<Float>
       return (a:Expr<T>) / EValue(b, cast VFloat);
-      
+
     @:op(a / b) static function divConst<T:Float, S>(a:T, b:Field<T, S>):Expr<Float>
       return EValue(a, cast VFloat) / (b:Expr<T>);
-      
+
     @:op(a % b) static function modByConst<T:Float, S>(a:Field<T, S>, b:T):Expr<T>
       return (a:Expr<T>) % EValue(b, cast VFloat);
-      
+
     @:op(a % b) static function modConst<T:Float, S>(a:T, b:Field<T, S>):Expr<T>
-      return EValue(a, cast VFloat) % (b:Expr<T>);  
+      return EValue(a, cast VFloat) % (b:Expr<T>);
   //} endregion
-    
+
   //{ region relations for constants
-    @:commutative  
+    @:commutative
     @:op(a == b) static function eqBool<S>(a:Field<Bool, S>, b:Bool):Condition
-      return (a:Expr<Bool>) == EValue(b, VBool); 
-    
+      return (a:Expr<Bool>) == EValue(b, VBool);
+
     @:commutative
     @:op(a != b) static function neqBool<S>(a:Field<Bool, S>, b:Bool):Condition
-      return (a:Expr<Bool>) != EValue(b, VBool); 
-      
-    @:commutative  
+      return (a:Expr<Bool>) != EValue(b, VBool);
+
+    @:commutative
     @:op(a == b) static function eqString<T:String, S>(a:Field<T, S>, b:String):Condition
       return (a:Expr<T>) == cast EValue(b, VString);
-    
+
     @:commutative
     @:op(a != b) static function neqString<T:String, S>(a:Field<T, S>, b:String):Condition
-      return (a:Expr<T>) != cast EValue(b, VString); 
-      
-    @:commutative  
+      return (a:Expr<T>) != cast EValue(b, VString);
+
+    @:commutative
     @:op(a == b) static function eqFloat<T:Float, S>(a:Field<T, S>, b:T):Condition
-      return (a:Expr<T>) == EValue(b, cast VFloat); 
-    
+      return (a:Expr<T>) == EValue(b, cast VFloat);
+
     @:commutative
     @:op(a != b) static function neqFloat<T:Float, S>(a:Field<T, S>, b:T):Condition
-      return (a:Expr<T>) != EValue(b, cast VFloat);    
-        
+      return (a:Expr<T>) != EValue(b, cast VFloat);
+
     @:op(a > b) static function gtConst<T:Float, S>(a:Field<T, S>, b:T):Condition
-      return (a:Expr<T>) > EValue(b, cast VFloat); 
-      
+      return (a:Expr<T>) > EValue(b, cast VFloat);
+
     @:op(a < b) static function ltConst<T:Float, S>(a:Field<T, S>, b:T):Condition
       return (a:Expr<T>) < EValue(b, cast VFloat);
-      
+
     @:op(a >= b) static function gteConst<T:Float, S>(a:Field<T, S>, b:T):Condition
       return (a:Expr<T>) >= EValue(b, cast VFloat);
-      
+
     @:op(a <= b) static function lteConst<T:Float, S>(a:Field<T, S>, b:T):Condition
       return (a:Expr<T>) <= EValue(b, cast VFloat);
-        
+
     @:op(a > b) static function gtDateConst<S>(a:Field<Date, S>, b:Date):Condition
-      return (a:Expr<Date>) > EValue(b, VDate); 
-      
+      return (a:Expr<Date>) > EValue(b, VDate);
+
     @:op(a < b) static function ltDateConst<S>(a:Field<Date, S>, b:Date):Condition
       return (a:Expr<Date>) < EValue(b, VDate);
-      
+
     @:op(a >= b) static function gteDateConst<S>(a:Field<Date, S>, b:Date):Condition
       return (a:Expr<Date>) >= EValue(b, VDate);
-      
+
     @:op(a <= b) static function lteDateConst<S>(a:Field<Date, S>, b:Date):Condition
       return (a:Expr<Date>) <= EValue(b, VDate);
-      
-  //} endregion  
-       
+
+  //} endregion
+
   //{ region logic
-    @:op(!a) static function not<X, Y>(c:Field<Bool, Y>):Condition 
+    @:op(!a) static function not<X, Y>(c:Field<Bool, Y>):Condition
       return EUnOp(Not, c, false);
-      
+
     @:op(a && b) static function and<X, Y>(a:Field<Bool, X>, b:Field<Bool, Y>):Condition
-      return EBinOp(And, a, b);    
-      
+      return EBinOp(And, a, b);
+
     @:op(a || b) static function or<X, Y>(a:Field<Bool, X>, b:Field<Bool, Y>):Condition
-      return EBinOp(Or, a, b);  
-  //} endregion    
+      return EBinOp(Or, a, b);
+  //} endregion
 }

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -8,8 +8,8 @@ import tink.sql.Limit;
 import tink.sql.Schema;
 
 class Format {
-  
-  static function binOp(o:BinOp<Dynamic, Dynamic, Dynamic>) 
+
+  static function binOp(o:BinOp<Dynamic, Dynamic, Dynamic>)
     return switch o {
       case Add: '+';
       case Subt: '-';
@@ -23,22 +23,22 @@ class Format {
       case Like: 'LIKE';
       case In: 'IN';
     }
-    
+
   static function unOp(o:UnOp<Dynamic, Dynamic>)
     return switch o {
       case IsNull: 'IS NULL';
       case Not: 'NOT';
-      case Neg: '-';      
+      case Neg: '-';
     }
-  
+
   static public function expr<A>(e:Expr<A>, s:Sanitizer):String {
-    
+
     inline function isEmptyArray(e:ExprData<Dynamic>)
       return e.match(EValue([], VArray(_)));
-      
+
     inline function json(v)
       return haxe.Json.stringify(v);
-      
+
     function rec(e:ExprData<Dynamic>)
       return
         switch e {
@@ -68,32 +68,32 @@ class Format {
             s.value(bytes);
           case EValue(geom, VGeometry(_)):
             'ST_GeomFromGeoJSON(\'${json(geom)}\')';
-          case EValue(value, VArray(VBool)):          
+          case EValue(value, VArray(VBool)):
             '(${value.map(s.value).join(', ')})';
-          case EValue(value, VArray(VInt)):          
+          case EValue(value, VArray(VInt)):
             '(${value.map(s.value).join(', ')})';
-          case EValue(value, VArray(VFloat)):          
+          case EValue(value, VArray(VFloat)):
             '(${value.map(s.value).join(', ')})';
-          case EValue(value, VArray(VString)):          
+          case EValue(value, VArray(VString)):
             '(${value.map(s.value).join(', ')})';
-          case EValue(value, VArray(VDate)):          
+          case EValue(value, VArray(VDate)):
             '(${value.map(s.value).join(', ')})';
-          case EValue(_, VArray(_)):          
+          case EValue(_, VArray(_)):
             throw 'Only arrays of primitive types are supported';
         }
-      
+
     return rec(e);
   }
-  
+
   static public function dropTable<Row:{}>(table:TableInfo<Row>, s:Sanitizer)
     return 'DROP TABLE ' + s.ident(table.getName());
-  
+
   static public function createTable<Row:{}>(table:TableInfo<Row>, s:Sanitizer, ifNotExists = false) {
     var sql = 'CREATE TABLE ';
     if(ifNotExists) sql += 'IF NOT EXISTS ';
     sql += s.ident(table.getName());
     sql += ' (';
-    
+
     sql += [for(f in table.getFields()) {
       var sql = s.ident(f.name) + ' ';
       sql += sqlType(f.type);
@@ -104,13 +104,13 @@ class Format {
       }
       sql;
     }].join(', ');
-    
+
     var schema: Schema = table.getFields();
     for (index in schema.indexes()) switch index.type {
       case IPrimary:
         sql += ', PRIMARY KEY (' + index.fields.map(s.ident).join(', ') + ')';
       case IUnique | IIndex:
-        var type = 
+        var type =
           if (index.type.equals(IUnique)) 'UNIQUE KEY'
           else 'INDEX';
         sql += ', $type ${s.ident(index.name)} (${index.fields.map(s.ident).join(', ')})';
@@ -127,10 +127,10 @@ class Format {
     ];
 
   static function schemaChange<Row:{}>(table:TableInfo<Row>, s:Sanitizer, change: SchemaChange) {
-    inline function alter(sql) 
+    inline function alter(sql)
       return 'ALTER TABLE ${s.ident(table.getName())} ${sql.join(' ')}';
-    inline function definition(f) 
-      return f.type + 
+    inline function definition(f)
+      return f.type +
         if (f.nullable) ' NULL' else ' NOT NULL' +
         if (f.autoIncrement) ' AUTO_INCREMENT' else '';
     inline function joinFields(fields)
@@ -147,7 +147,7 @@ class Format {
         case IPrimary: 'PRIMARY KEY';
       }]);
     return switch change {
-      case AddColumn(f): 
+      case AddColumn(f):
         [alter(['ADD COLUMN', s.ident(f.name), definition(f)])];
       case RemoveColumn(f):
         [alter(['DROP COLUMN', s.ident(f.name)])];
@@ -161,8 +161,8 @@ class Format {
         [removeIndex(from), addIndex(to)];
     }
   }
-  
-  static public function sqlType(type: DataType): String 
+
+  static public function sqlType(type: DataType): String
     return switch type {
       case DBool:
         'TINYINT(1)';
@@ -173,6 +173,13 @@ class Format {
       case DString(maxLength): // Todo: separate types
         if(maxLength < 65536) 'VARCHAR($maxLength)';
         else 'TEXT';
+      case DText(size):
+        switch size {
+          case Tiny: 'TINYTEXT';
+          case Default: 'TEXT';
+          case Medium: 'MEDIUMTEXT';
+          case Long: 'LONGTEXT';
+        }
       case DBlob(maxLength):
         if(maxLength < 65536) 'VARBINARY($maxLength)';
         else 'BLOB';
@@ -183,7 +190,7 @@ class Format {
       case DMultiPolygon:
         'MULTIPOLYGON';
     }
-  
+
   static public function columnInfo<Row:{}>(table:TableInfo<Row>, s:Sanitizer) {
     return 'SHOW COLUMNS FROM ${s.ident(table.getName())}';
   }
@@ -192,54 +199,54 @@ class Format {
     return 'SHOW INDEX FROM ${s.ident(table.getName())}';
   }
 
-  static public function selectAll<A:{}, Db>(t:Target<A, Db>, ?c:Condition, s:Sanitizer, ?limit:Limit, ?orderBy:OrderBy<A>)         
+  static public function selectAll<A:{}, Db>(t:Target<A, Db>, ?c:Condition, s:Sanitizer, ?limit:Limit, ?orderBy:OrderBy<A>)
     return select(t, '*', c, s, limit, orderBy);
 
   static public function countAll<A:{}, Db>(t:Target<A, Db>, ?c:Condition, s:Sanitizer)
     return select(t, 'COUNT(*) as count', c, s);
-  
+
   static function select<A:{}, Db>(t:Target<A, Db>, what:String, ?c:Condition, s:Sanitizer, ?limit:Limit, ?orderBy:OrderBy<A>) {
     var sql = 'SELECT $what FROM ' + target(t, s);
-    
+
     if (c != null)
       sql += ' WHERE ' + expr(c, s);
-      
+
     if (orderBy != null)
       sql += ' ORDER BY ' + [for(o in orderBy) s.ident(o.field.table) + '.' + s.ident(o.field.name) + ' ' + o.order.getName().toUpperCase()].join(', ');
-      
-    if (limit != null) 
+
+    if (limit != null)
       sql += ' LIMIT ${limit.limit} OFFSET ${limit.offset}';
-      
-    return sql;    
+
+    return sql;
   }
-  
-  static public function selectProjection<A:{}, Db, Ret>(t:Target<A, Db>, ?c:Condition, s:Sanitizer, p:Projection<A, Ret>, ?limit) 
+
+  static public function selectProjection<A:{}, Db, Ret>(t:Target<A, Db>, ?c:Condition, s:Sanitizer, p:Projection<A, Ret>, ?limit)
     return select(t, (if (p.distinct) 'DISTINCT ' else '') + [
       for (part in p) (
         switch part.expr.data {
           case null: '';
           case v: expr(v, s) + ' AS ';
         }
-      ) + s.value(part.name)      
+      ) + s.value(part.name)
     ].join(', '), c, s, limit);
-    
+
   static public function insert<Row:{}>(table:TableInfo<Row>, rows:Array<Insert<Row>>, s:Sanitizer) {
     return
       'INSERT INTO ${s.ident(table.getName())} (${[for (f in table.fieldnames()) s.ident(f)].join(", ")}) VALUES ' +
          [for (row in rows) '(' + table.sqlizeRow(row, s.value).join(', ') + ')'].join(', ');
   }
-  
+
   static public function target<A:{}, Db>(t:Target<A, Db>, s:Sanitizer)
     return switch t {
-      case TTable(name, alias): 
-        
+      case TTable(name, alias):
+
         s.ident(name) + switch alias {
           case null: '';
           case v: ' AS ' + s.ident(alias);
         }
-                
-      case TJoin(left, right, type, cond): 
-      
+
+      case TJoin(left, right, type, cond):
+
         target(left, s) + ' '+(switch type {
           case Inner: 'INNER';
           case Right: 'RIGHT';
@@ -247,35 +254,35 @@ class Format {
           //case Outer: 'FULL OUTER';
         }) + ' JOIN ' + target(right, s) + ' ON ' + expr(cond, s);
     }
-    
+
     static public function update<Row:{}>(table:TableInfo<Row>, c:Null<Condition>, max:Null<Int>, update:Update<Row>, s:Sanitizer) {
-      var ret = 
-        'UPDATE ${table.getName()} SET ' + 
-          [for (u in update) 
+      var ret =
+        'UPDATE ${table.getName()} SET ' +
+          [for (u in update)
             s.ident(u.field.name) + ' = ' + expr(u.expr.data, s)
           ].join(', ');
-      
+
       if (c != null)
         ret += ' WHERE ' + expr(c, s);
-        
+
       if (max != null)
         ret += ' LIMIT '+s.value(max);
-        
+
       return ret;
     }
-    
+
     static public function delete<Row:{}>(table:TableInfo<Row>, c:Null<Condition>, max:Null<Int>, s:Sanitizer) {
       var ret = 'DELETE FROM ${table.getName()} ';
-      
+
       if (c != null)
         ret += ' WHERE ' + expr(c, s);
-        
+
       if (max != null)
         ret += ' LIMIT '+s.value(max);
-        
+
       return ret;
     }
-  
+
 }
 
 interface Sanitizer {

--- a/src/tink/sql/Info.hx
+++ b/src/tink/sql/Info.hx
@@ -5,7 +5,7 @@ import tink.core.Any;
 
 interface DatabaseInfo {
   function tablesnames():Iterable<String>;
-  function tableinfo<Row:{}>(name:String):TableInfo<Row>;  
+  function tableinfo<Row:{}>(name:String):TableInfo<Row>;
 }
 
 interface TableInfo<Row:{}> {
@@ -14,13 +14,13 @@ interface TableInfo<Row:{}> {
   function fieldnames():Iterable<String>;
   function sqlizeRow(row:Insert<Row>, val:Any->String):Array<String>;
 }
-  
+
 typedef Column = {
   > FieldType,
   name:String,
   keys:Array<KeyType>,
 }
-  
+
 typedef FieldType = {
   nullable:Bool,
   type:DataType,
@@ -37,10 +37,18 @@ enum DataType {
   DInt(bits:Int, signed:Bool, autoIncrement:Bool);
   DFloat(bits:Int);
   DString(maxLength:Int);
+  DText(size:TextSize);
   DBlob(maxLength:Int);
   DDateTime;
   DPoint; // geojson
   DMultiPolygon; // geojson
+}
+
+enum TextSize {
+  Tiny;
+  Default;
+  Medium;
+  Long;
 }
 
 typedef Insert<Row> = Row;

--- a/src/tink/sql/Types.hx
+++ b/src/tink/sql/Types.hx
@@ -57,8 +57,7 @@ typedef Number<@:const L> = Float;
 typedef Point = geojson.Point;
 #end
 
-// TODO: rename to Text
-typedef DefaultText = String;
+typedef Text = String;
 
 typedef TinyText = String;
 

--- a/src/tink/sql/Types.hx
+++ b/src/tink/sql/Types.hx
@@ -1,36 +1,69 @@
-package tink.sql.types;
+package tink.sql;
 
 import tink.sql.Expr;
 import tink.json.Representation;
 
+typedef Blob<@:const L> = haxe.io.Bytes;
+
+typedef Boolean = Bool;
+
+typedef DateTime = Date;
+
 abstract Id<T>(Int) to Int {
-  
-  public inline function new(v) 
+
+  public inline function new(v)
     this = v;
-  
+
   @:from static inline function ofStringly<T>(s:tink.Stringly):Id<T>
     return new Id(s);
-  
+
   @:from static inline function ofInt<T>(i:Int):Id<T>
     return new Id(i);
-    
-  @:to public inline function toString() 
+
+  @:to public inline function toString()
     return Std.string(this);
-    
+
   @:to public function toExpr():Expr<Id<T>>
     return Expr.ExprData.EValue(new Id(this), cast VInt);
-    
+
   @:from static inline function ofRe<T>(r:Representation<Int>):Id<T>
     return new Id(r.get());
-  
+
   @:to inline function toRep():Representation<Int>
     return new Representation(this);
-    
+
   @:op(A>B) static function gt<T>(a:Id<T>, b:Id<T>):Bool;
   @:op(A<B) static function lt<T>(a:Id<T>, b:Id<T>):Bool;
   @:op(A>=B) static function gte<T>(a:Id<T>, b:Id<T>):Bool;
   @:op(A>=B) static function lte<T>(a:Id<T>, b:Id<T>):Bool;
   @:op(A==B) static function eq<T>(a:Id<T>, b:Id<T>):Bool;
   @:op(A!=B) static function neq<T>(a:Id<T>, b:Id<T>):Bool;
-    
+
 }
+
+typedef Integer<@:const L> = Int;
+
+typedef LongText = String;
+
+typedef MediumText = String;
+
+#if geojson
+typedef MultiPolygon = geojson.MultiPolygon;
+#end
+
+typedef Number<@:const L> = Float;
+
+#if geojson
+typedef Point = geojson.Point;
+#end
+
+// TODO: rename to Text
+typedef DefaultText = String;
+
+typedef TinyText = String;
+
+typedef VarChar<@:const L> = String;
+
+
+
+

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -15,13 +15,13 @@ import tink.streams.RealStream;
 using tink.CoreApi;
 
 class MySql implements Driver {
-  
+
   var settings:MySqlSettings;
-  
+
   public function new(settings) {
     this.settings = settings;
   }
-  
+
   public function open<Db:DatabaseInfo>(name:String, info:Db):Connection<Db> {
     var cnx = NativeDriver.createPool({
       user: settings.user,
@@ -31,28 +31,28 @@ class MySql implements Driver {
       database: name,
       connectionLimit: 3,
     });
-    
+
     return new MySqlConnection(info, cnx);
-  }  
+  }
 }
 
 class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sanitizer {
-  
+
   var cnx:NativeConnection;
   var db:Db;
-  
+
   public function value(v:Any):String
     return NativeDriver.escape(if(Std.is(v, Bytes)) Buffer.hxFromBytes(v) else v);
-    
-  public function ident(s:String):String 
+
+  public function ident(s:String):String
     return NativeDriver.escapeId(s);
-  
+
   public function new(db, cnx) {
     this.db = db;
     this.cnx = cnx;
   }
 
-  function query<T>(options: QueryOptions):Promise<T> 
+  function query<T>(options: QueryOptions):Promise<T>
     return Future.async(function (done) {
       cnx.query(options, function (err, res) {
         if (err != null) done(toError(err));
@@ -62,44 +62,44 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
 
   function toError<A>(error:js.Error):Outcome<A, Error>
     return Failure(Error.withData(error.message, error));
-  
+
   public function dropTable<Row:{}>(table:TableInfo<Row>):Promise<Noise>
     return query({sql: Format.dropTable(table, this)});
-        
+
   public function createTable<Row:{}>(table:TableInfo<Row>):Promise<Noise>
     return query({sql: Format.createTable(table, this)});
-  
+
   public function selectAll<A:{}>(t:Target<A, Db>, ?c:Condition, ?limit:Limit, ?orderBy:OrderBy<A>):RealStream<A> {
     var nest = !t.match(TTable(_, _));
-    return Stream.promise(query({ 
-      sql: Format.selectAll(t, c, this, limit, orderBy), 
+    return Stream.promise(query({
+      sql: Format.selectAll(t, c, this, limit, orderBy),
       nestTables: nest,
       typeCast: typeCast
     }).next(function (res)
       return Stream.ofIterator(rowIterator(res, nest))
     ));
   }
-  
+
   public function countAll<A:{}>(t:Target<A, Db>, ?c:Condition):Promise<Int>
     return query({sql: Format.countAll(t, c, this)}).next(function(res)
       return (res[0].count: Int)
     );
-  
-  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>):Promise<Id<Row>> 
+
+  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>):Promise<Id<Row>>
     return query({sql: Format.insert(table, items, this)}).next(function(res)
       return new Id(res.insertId)
     );
-        
+
   public function update<Row:{}>(table:TableInfo<Row>, ?c:Condition, ?max:Int, update:Update<Row>):Promise<{rowsAffected:Int}>
     return query({sql: Format.update(table, c, max, update, this)}).next(function(res)
       return {rowsAffected: res.changedRows}
     );
-        
+
   public function delete<Row:{}>(table:TableInfo<Row>, ?c:Condition, ?max:Int):Promise<{rowsAffected:Int}>
     return query({sql: Format.delete(table, c, max, this)}).next(function(res)
       return {rowsAffected: res.changedRows}
     );
-  
+
   public function diffSchema<Row:{}>(table:TableInfo<Row>):Promise<Array<SchemaChange>> {
     function iter(res) return rowIterator(res);
     return Promise.inParallel([
@@ -113,7 +113,7 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
       default: throw "assert";
     });
   }
-  
+
   public function updateSchema<Row:{}>(table:TableInfo<Row>, changes:Array<SchemaChange>):Promise<Noise>
     return Promise.inSequence([
       for (change in Format.alterTable(table, this, changes))
@@ -125,13 +125,25 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
       case 'BLOB':
         switch (field.buffer():Buffer) {
           case null: null;
-          case buf: buf.hxToBytes();
+          case buf:
+            // MySQL.js sometimes returns TEXT fields as BLOB, see https://github.com/mysqljs/mysql#string
+            var columns = [for (f in db.tableinfo(field.table).getFields()) f];
+            var column = columns.filter(function (f) return f.name == field.name)[0];
+            if (column == null) {
+              throw 'Failed to find type of ${field.table}.${field.name}';
+            }
+            switch column.type {
+              case DText(_), DString(_):
+                buf.toString();
+              case _:
+                buf.hxToBytes();
+            }
         }
       case 'TINY' if(field.length == 1):
         switch field.string() {
           case null: null;
           case v: v != '0';
-        } 
+        }
       case 'GEOMETRY':
         var v:Dynamic = field.geometry();
         // https://github.com/mysqljs/mysql/blob/310c6a7d1b2e14b63b572dbfbfa10128f20c6d52/lib/protocol/Parser.js#L342-L389
@@ -204,7 +216,7 @@ private typedef Config = {>MySqlSettings,
 
 private typedef QueryOptions = {
   sql:String,
-  ?nestTables:Bool, 
+  ?nestTables:Bool,
   ?typeCast:Dynamic->(Void->Dynamic)->Dynamic
 }
 

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -9,7 +9,7 @@ import tink.sql.Limit;
 import tink.sql.Expr;
 import tink.sql.Info;
 import tink.sql.Schema;
-import tink.sql.types.Id;
+import tink.sql.Types;
 import tink.streams.Stream;
 import tink.streams.RealStream;
 using tink.CoreApi;

--- a/src/tink/sql/macros/TableBuilder.hx
+++ b/src/tink/sql/macros/TableBuilder.hx
@@ -82,7 +82,7 @@ class TableBuilder {
                           macro tink.sql.Info.DataType.DBlob($v{maxLength});
                         case {module: 'tink.sql.Types', name: 'DateTime'}:
                           macro tink.sql.Info.DataType.DDateTime;
-                        case {module: 'tink.sql.Types', name: 'DefaultText'}:
+                        case {module: 'tink.sql.Types', name: 'Text'}:
                           macro tink.sql.Info.DataType.DText(tink.sql.Info.TextSize.Default);
                         case {module: 'tink.sql.Types', name: 'Integer'}:
                           var maxLength = getInt(params[0], f.pos);

--- a/src/tink/sql/types/Blob.hx
+++ b/src/tink/sql/types/Blob.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef Blob<@:const L> = haxe.io.Bytes;

--- a/src/tink/sql/types/Boolean.hx
+++ b/src/tink/sql/types/Boolean.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef Boolean = Bool;

--- a/src/tink/sql/types/DateTime.hx
+++ b/src/tink/sql/types/DateTime.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef DateTime = Date;

--- a/src/tink/sql/types/Integer.hx
+++ b/src/tink/sql/types/Integer.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef Integer<@:const L> = Int;

--- a/src/tink/sql/types/MultiPolygon.hx
+++ b/src/tink/sql/types/MultiPolygon.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef MultiPolygon = geojson.MultiPolygon;

--- a/src/tink/sql/types/Number.hx
+++ b/src/tink/sql/types/Number.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef Number<@:const L> = Float;

--- a/src/tink/sql/types/Point.hx
+++ b/src/tink/sql/types/Point.hx
@@ -1,3 +1,0 @@
-package tink.sql.types;
-
-typedef Point = geojson.Point;

--- a/src/tink/sql/types/Text.hx
+++ b/src/tink/sql/types/Text.hx
@@ -1,8 +1,0 @@
-package tink.sql.types;
-
-typedef Text<@:const L> = String;
-
-typedef TinyText = String;
-typedef DefaultText = String;
-typedef MediumText = String;
-typedef LongText = String;

--- a/src/tink/sql/types/Text.hx
+++ b/src/tink/sql/types/Text.hx
@@ -1,3 +1,8 @@
 package tink.sql.types;
 
 typedef Text<@:const L> = String;
+
+typedef TinyText = String;
+typedef DefaultText = String;
+typedef MediumText = String;
+typedef LongText = String;

--- a/tests/Db.hx
+++ b/tests/Db.hx
@@ -28,25 +28,25 @@ typedef Types = {
   public var date(default, null):DateTime;
   public var boolTrue(default, null):Bool;
   public var boolFalse(default, null):Bool;
-  
+
   @:optional public var optionalInt(default, null):Integer<21>;
   @:optional public var optionalText(default, null):Text<40>;
   @:optional public var optionalBlob(default, null):Blob<1000000>;
   @:optional public var optionalDate(default, null):DateTime;
   @:optional public var optionalBool(default, null):Bool;
-  
+
   public var nullInt(default, null):Null<Integer<21>>;
   public var nullText(default, null):Null<Text<40>>;
   public var nullBlob(default, null):Null<Blob<1000000>>;
   public var nullDate(default, null):Null<DateTime>;
   public var nullBool(default, null):Null<Bool>;
-  
+
   @:optional public var abstractInt(default, null):AInt;
   @:optional public var abstractFloat(default, null):AFloat;
   @:optional public var abstractString(default, null):AString;
   @:optional public var abstractBool(default, null):ABool;
   @:optional public var abstractDate(default, null):ADate;
-  
+
   @:optional public var enumAbstractInt(default, null):EInt;
   @:optional public var enumAbstractFloat(default, null):EFloat;
   @:optional public var enumAbstractString(default, null):EString;
@@ -83,7 +83,19 @@ typedef Schema = {
   @:unique('gh') public var h(default, null): Boolean;
 }
 
-@:tables(User, Post, PostTags, Types, Geometry, Schema)
+typedef StringTypes = {
+  @:autoIncrement @:primary public var id(default, null):Id<User>;
+  public var text10(default, null): Text<20>;
+  public var text255(default, null): Text<255>;
+  public var text999(default, null): Text<999>;
+  public var text65536(default, null): Text<65536>;
+  public var textTiny(default, null): Text.TinyText;
+  public var textDefault(default, null): Text.DefaultText;
+  public var textMedium(default, null): Text.MediumText;
+  public var textLong(default, null): Text.LongText;
+}
+
+@:tables(User, Post, PostTags, Types, Geometry, Schema, StringTypes)
 class Db extends tink.sql.Database {}
 
 abstract AInt(Integer<1>) from Int to Int {}

--- a/tests/Db.hx
+++ b/tests/Db.hx
@@ -90,7 +90,7 @@ typedef StringTypes = {
   public var text999(default, null): VarChar<999>;
   public var text65536(default, null): VarChar<65536>;
   public var textTiny(default, null): TinyText;
-  public var textDefault(default, null): DefaultText;
+  public var textDefault(default, null): Text;
   public var textMedium(default, null): MediumText;
   public var textLong(default, null): LongText;
 }

--- a/tests/Db.hx
+++ b/tests/Db.hx
@@ -1,42 +1,42 @@
 package;
 
-import tink.sql.types.*;
+import tink.sql.Types;
 
 typedef User = {
   @:autoIncrement @:primary public var id(default, null):Id<User>;
-  public var name(default, null):Text<50>;
-  public var email(default, null):Text<50>;
+  public var name(default, null):VarChar<50>;
+  public var email(default, null):VarChar<50>;
 }
 
 typedef Post = {
   @:autoIncrement @:primary public var id(default, null):Id<Post>;
   public var author(default, null):Id<User>;
-  public var title(default, null):Text<50>;
-  public var content(default, null):Text<50>;
+  public var title(default, null):VarChar<50>;
+  public var content(default, null):VarChar<50>;
 }
 
 typedef PostTags = {
   public var post(default, null):Id<Post>;
-  public var tag(default, null):Text<50>;
+  public var tag(default, null):VarChar<50>;
 }
 
 typedef Types = {
   public var int(default, null):Integer<21>;
   public var float(default, null):Number<21>;
-  public var text(default, null):Text<40>;
+  public var text(default, null):VarChar<40>;
   public var blob(default, null):Blob<1000000>;
   public var date(default, null):DateTime;
   public var boolTrue(default, null):Bool;
   public var boolFalse(default, null):Bool;
 
   @:optional public var optionalInt(default, null):Integer<21>;
-  @:optional public var optionalText(default, null):Text<40>;
+  @:optional public var optionalText(default, null):VarChar<40>;
   @:optional public var optionalBlob(default, null):Blob<1000000>;
   @:optional public var optionalDate(default, null):DateTime;
   @:optional public var optionalBool(default, null):Bool;
 
   public var nullInt(default, null):Null<Integer<21>>;
-  public var nullText(default, null):Null<Text<40>>;
+  public var nullText(default, null):Null<VarChar<40>>;
   public var nullBlob(default, null):Null<Blob<1000000>>;
   public var nullDate(default, null):Null<DateTime>;
   public var nullBool(default, null):Null<Bool>;
@@ -63,8 +63,8 @@ typedef Schema = {
   public var toBoolean(default, null): Boolean;
   public var toInt(default, null): Integer<11>;
   public var toFloat(default, null): Number<11>;
-  public var toText(default, null): Text<1>;
-  public var toLongText(default, null): Text<999999>;
+  public var toText(default, null): VarChar<1>;
+  public var toLongText(default, null): VarChar<999999>;
   public var toDate(default, null): DateTime;
 
   public var toAdd(default, null): Boolean;
@@ -85,14 +85,14 @@ typedef Schema = {
 
 typedef StringTypes = {
   @:autoIncrement @:primary public var id(default, null):Id<User>;
-  public var text10(default, null): Text<20>;
-  public var text255(default, null): Text<255>;
-  public var text999(default, null): Text<999>;
-  public var text65536(default, null): Text<65536>;
-  public var textTiny(default, null): Text.TinyText;
-  public var textDefault(default, null): Text.DefaultText;
-  public var textMedium(default, null): Text.MediumText;
-  public var textLong(default, null): Text.LongText;
+  public var text10(default, null): VarChar<20>;
+  public var text255(default, null): VarChar<255>;
+  public var text999(default, null): VarChar<999>;
+  public var text65536(default, null): VarChar<65536>;
+  public var textTiny(default, null): TinyText;
+  public var textDefault(default, null): DefaultText;
+  public var textMedium(default, null): MediumText;
+  public var textLong(default, null): LongText;
 }
 
 @:tables(User, Post, PostTags, Types, Geometry, Schema, StringTypes)
@@ -100,11 +100,11 @@ class Db extends tink.sql.Database {}
 
 abstract AInt(Integer<1>) from Int to Int {}
 abstract AFloat(Number<1>) from Float to Float {}
-abstract AString(Text<255>) from String to String {}
+abstract AString(VarChar<255>) from String to String {}
 abstract ABool(Boolean) from Bool to Bool {}
 abstract ADate(DateTime) from Date to Date {}
 
 @:enum abstract EInt(Integer<1>) to Int {var I = 1;}
 @:enum abstract EFloat(Number<1>) to Float {var F = 1.0;}
-@:enum abstract EString(Text<255>) to String {var S = 'a';}
+@:enum abstract EString(VarChar<255>) to String {var S = 'a';}
 @:enum abstract EBool(Boolean) to Bool {var B = true;}

--- a/tests/FormatTest.hx
+++ b/tests/FormatTest.hx
@@ -2,23 +2,23 @@ package;
 
 import tink.sql.Format;
 import tink.sql.Info;
-import tink.sql.types.*;
+import tink.sql.Types;
 import tink.unit.Assert.assert;
 
 using tink.CoreApi;
 
 @:allow(tink.unit)
 class FormatTest extends TestWithDb {
-	
+
 	var uniqueDb:UniqueDb;
 	var sanitizer:Sanitizer;
-	
+
 	public function new(driver, db) {
 		super(driver, db);
 		uniqueDb = new UniqueDb('test', driver);
 		sanitizer = new tink.sql.drivers.node.MySql.MySqlConnection(null, null);
 	}
-	
+
 	@:variant(new FormatTest.FakeTable1(), 'CREATE TABLE `fake` (`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT, `username` VARCHAR(50) NOT NULL, `admin` TINYINT(1) NOT NULL, `age` INT(11) UNSIGNED NULL)')
 	@:variant(this.db.User, 'CREATE TABLE `User` (`email` VARCHAR(50) NOT NULL, `id` INT(12) UNSIGNED NOT NULL AUTO_INCREMENT, `name` VARCHAR(50) NOT NULL, PRIMARY KEY (`id`))')
 	@:variant(this.db.Types, 'CREATE TABLE `Types` (`abstractBool` TINYINT(1) NULL, `abstractDate` DATETIME NULL, `abstractFloat` FLOAT(1) NULL, `abstractInt` INT(1) UNSIGNED NULL, `abstractString` VARCHAR(255) NULL, `blob` BLOB NOT NULL, `boolFalse` TINYINT(1) NOT NULL, `boolTrue` TINYINT(1) NOT NULL, `date` DATETIME NOT NULL, `enumAbstractBool` TINYINT(1) NULL, `enumAbstractFloat` FLOAT(1) NULL, `enumAbstractInt` INT(1) UNSIGNED NULL, `enumAbstractString` VARCHAR(255) NULL, `float` FLOAT(21) NOT NULL, `int` INT(21) UNSIGNED NOT NULL, `nullBlob` BLOB NULL, `nullBool` TINYINT(1) NULL, `nullDate` DATETIME NULL, `nullInt` INT(21) UNSIGNED NULL, `nullText` VARCHAR(40) NULL, `optionalBlob` BLOB NULL, `optionalBool` TINYINT(1) NULL, `optionalDate` DATETIME NULL, `optionalInt` INT(21) UNSIGNED NULL, `optionalText` VARCHAR(40) NULL, `text` VARCHAR(40) NOT NULL)')
@@ -27,17 +27,17 @@ class FormatTest extends TestWithDb {
 		// TODO: should separate out the sanitizer
 		return assert(Format.createTable(table, sanitizer) == sql);
 	}
-	
+
 	public function like() {
 		var dataset = db.Types.where(Types.text.like('mystring'));
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`text` LIKE \'mystring\')');
 	}
-	
+
 	public function inArray() {
 		var dataset = db.Types.where(Types.int.inArray([1, 2, 3]));
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`int` IN (1, 2, 3))');
 	}
-	
+
 	public function inEmptyArray() {
 		var dataset = db.Types.where(Types.int.inArray([]));
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE false');
@@ -47,17 +47,17 @@ class FormatTest extends TestWithDb {
 		var dataset = db.Types.as('alias');
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` AS `alias`');
 	}
-	
+
 	public function tableAliasJoin() {
 		var dataset = db.Types.leftJoin(db.Types.as('alias')).on(Types.int == alias.int);
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` LEFT JOIN `Types` AS `alias` ON (`Types`.`int` = `alias`.`int`)');
 	}
-	
+
 	public function orderBy() {
 		var dataset = db.Types;
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer, {limit: 1, offset: 0}, [{field: db.Types.fields.int, order: Desc}]) == 'SELECT * FROM `Types` ORDER BY `Types`.`int` DESC LIMIT 1 OFFSET 0');
 	}
-	
+
 	// https://github.com/haxetink/tink_sql/issues/10
 	// public function compareNull() {
 	// 	var dataset = db.Types.where(Types.optionalInt == null);
@@ -66,10 +66,10 @@ class FormatTest extends TestWithDb {
 }
 
 class FakeTable1 extends FakeTable {
-	
+
 	override function getName():String
 		return 'fake';
-	
+
 	override function getFields():Iterable<Column>
 		return [
 			{name: 'id', nullable: false, type: DInt(11, false, true), keys: []},
@@ -81,16 +81,16 @@ class FakeTable1 extends FakeTable {
 
 class FakeTable implements TableInfo<{}> {
 	public function new() {}
-	
+
 	public function getName():String
 		throw 'abstract';
-		
+
 	public function getFields():Iterable<Column>
 		throw 'abstract';
-		
+
 	public function fieldnames():Iterable<String>
 		return [for(f in getFields()) f.name];
-	
+
 	public function sqlizeRow(row:Insert<{}>, val:Any->String):Array<String>
 		return null;
 }
@@ -99,7 +99,7 @@ class FakeTable implements TableInfo<{}> {
 class UniqueDb extends tink.sql.Database {}
 
 typedef UniqueTable = {
-  @:unique var u1(default, null):Text<123>;
-  @:unique('index_name1') var u2(default, null):Text<123>;
-  @:unique('index_name1') var u3(default, null):Text<123>;
+  @:unique var u1(default, null):VarChar<123>;
+  @:unique('index_name1') var u2(default, null):VarChar<123>;
+  @:unique('index_name1') var u3(default, null):VarChar<123>;
 }

--- a/tests/StringTest.hx
+++ b/tests/StringTest.hx
@@ -12,22 +12,22 @@ using tink.CoreApi;
 @:allow(tink.unit)
 class StringTest extends TestWithDb {
 
-	@:before
-	public function createTable() {
-		return db.StringTypes.create();
-	}
+  @:before
+  public function createTable() {
+    return db.StringTypes.create();
+  }
 
-	@:after
-	public function dropTable() {
-		return db.StringTypes.drop();
-	}
+  @:after
+  public function dropTable() {
+    return db.StringTypes.drop();
+  }
 
-	public function insert() {
-		var mydate = new Date(2000, 0, 1, 0, 0, 0);
+  public function insert() {
+    var mydate = new Date(2000, 0, 1, 0, 0, 0);
     function generateString(length) {
       return StringTools.lpad("", ".", length);
     }
-		var future = db.StringTypes.insertOne({
+    var future = db.StringTypes.insertOne({
       id: null,
       text10: generateString(10),
       text255: generateString(255),
@@ -38,9 +38,9 @@ class StringTest extends TestWithDb {
       textDefault: generateString(65535),
       textMedium: generateString(70000),
       textLong: generateString(80000),
-		})
-			.next(function(id:Int) return db.StringTypes.first())
-			.next(function(row:StringTypes) {
+    })
+      .next(function(id:Int) return db.StringTypes.first())
+      .next(function(row:StringTypes) {
         asserts.assert(row.text10 == generateString(10));
         asserts.assert(row.text255 == generateString(255));
         asserts.assert(row.text999 == generateString(999));
@@ -50,14 +50,14 @@ class StringTest extends TestWithDb {
         asserts.assert(row.textMedium == generateString(70000));
         asserts.assert(row.textLong == generateString(80000));
 
-				return Noise;
-			});
+        return Noise;
+      });
 
-		future.handle(function(o) switch o {
-			case Success(_): asserts.done();
-			case Failure(e): asserts.fail(e, e.pos);
-		});
+    future.handle(function(o) switch o {
+      case Success(_): asserts.done();
+      case Failure(e): asserts.fail(e, e.pos);
+    });
 
-		return asserts;
-	}
+    return asserts;
+  }
 }

--- a/tests/StringTest.hx
+++ b/tests/StringTest.hx
@@ -32,7 +32,7 @@ class StringTest extends TestWithDb {
       text10: generateString(10),
       text255: generateString(255),
       text999: generateString(999),
-      // Note: even though the type is Text<65536> it is a Text column, so max length 65535
+      // Note: even though the type is VarChar<65536> it is a Text column, so max length 65535
       text65536: generateString(65535),
       textTiny: generateString(255),
       textDefault: generateString(65535),

--- a/tests/StringTest.hx
+++ b/tests/StringTest.hx
@@ -1,0 +1,63 @@
+package;
+
+import Db;
+import tink.sql.Format;
+import tink.sql.Info;
+import tink.sql.drivers.MySql;
+import tink.unit.Assert.assert;
+
+using tink.CoreApi;
+
+@:asserts
+@:allow(tink.unit)
+class StringTest extends TestWithDb {
+
+	@:before
+	public function createTable() {
+		return db.StringTypes.create();
+	}
+
+	@:after
+	public function dropTable() {
+		return db.StringTypes.drop();
+	}
+
+	public function insert() {
+		var mydate = new Date(2000, 0, 1, 0, 0, 0);
+    function generateString(length) {
+      return StringTools.lpad("", ".", length);
+    }
+		var future = db.StringTypes.insertOne({
+      id: null,
+      text10: generateString(10),
+      text255: generateString(255),
+      text999: generateString(999),
+      // Note: even though the type is Text<65536> it is a Text column, so max length 65535
+      text65536: generateString(65535),
+      textTiny: generateString(255),
+      textDefault: generateString(65535),
+      textMedium: generateString(70000),
+      textLong: generateString(80000),
+		})
+			.next(function(id:Int) return db.StringTypes.first())
+			.next(function(row:StringTypes) {
+        asserts.assert(row.text10 == generateString(10));
+        asserts.assert(row.text255 == generateString(255));
+        asserts.assert(row.text999 == generateString(999));
+        asserts.assert(row.text65536 == generateString(65535));
+        asserts.assert(row.textTiny == generateString(255));
+        asserts.assert(row.textDefault == generateString(65535));
+        asserts.assert(row.textMedium == generateString(70000));
+        asserts.assert(row.textLong == generateString(80000));
+
+				return Noise;
+			});
+
+		future.handle(function(o) switch o {
+			case Success(_): asserts.done();
+			case Failure(e): asserts.fail(e, e.pos);
+		});
+
+		return asserts;
+	}
+}


### PR DESCRIPTION
- Add `Text.TinyText`, `Text.DefaultText`, `Text.MediumText`, `Text.LongText`
    - Make these correspond with SQL types
    - I'm open to a better suggestion for naming of these types, or promoting them to their own modules etc.
    - Add some unit tests
- Fix node JS mysql driver to correctly handle cases where TEXT columns are returned as a NodeJS Buffer
- Add some stuff to the README
- Accidentally clean up whitespace (sorry about this and the messy commit, I didn't realise VSC had reformatted this when I committed)