### PR TITLE
Add IGNORE option to INSERT

### DIFF
--- a/src/tink/sql/Connection.hx
+++ b/src/tink/sql/Connection.hx
@@ -20,7 +20,7 @@ interface Connection<Db> {
   function updateSchema<Row:{}>(table:TableInfo<Row>, changes:Array<SchemaChange>):Promise<Noise>;
   function selectAll<A:{}>(t:Target<A, Db>, ?c:Condition, ?limit:Limit, ?orderBy:OrderBy<A>):RealStream<A>;
   function countAll<A:{}>(t:Target<A, Db>, ?c:Condition):Promise<Int>;
-  function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>):Promise<Id<Row>>;
+  function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>, ?options:InsertOptions):Promise<Id<Row>>;
   function update<Row:{}>(table:TableInfo<Row>, ?c:Condition, ?max:Int, update:Update<Row>):Promise<{ rowsAffected: Int }>;
   function delete<Row:{}>(table:TableInfo<Row>, ?c:Condition, ?max:Int):Promise<{ rowsAffected: Int }>;
 }
@@ -36,4 +36,8 @@ class FieldUpdate<Row> {
     this.field = field;
     this.expr = expr;
   }
+}
+
+typedef InsertOptions = {
+  ?ignore:Bool,
 }

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -226,7 +226,7 @@ class Format {
   static public function insert<Row:{}>(table:TableInfo<Row>, rows:Array<Insert<Row>>, s:Sanitizer, options:InsertOptions) {
     var ignore = options != null && options.ignore;
     return
-      'INSERT ${ignore ? 'IGNORE' : ''} INTO ${s.ident(table.getName())} (${[for (f in table.fieldnames()) s.ident(f)].join(", ")}) VALUES ' +
+      'INSERT ${ignore ? 'IGNORE ' : ''}INTO ${s.ident(table.getName())} (${[for (f in table.fieldnames()) s.ident(f)].join(", ")}) VALUES ' +
          [for (row in rows) '(' + table.sqlizeRow(row, s.value).join(', ') + ')'].join(', ');
   }
   

--- a/src/tink/sql/Format.hx
+++ b/src/tink/sql/Format.hx
@@ -1,7 +1,7 @@
 package tink.sql;
 
 import tink.core.Any;
-import tink.sql.Connection.Update;
+import tink.sql.Connection;
 import tink.sql.Expr;
 import tink.sql.Info;
 import tink.sql.Limit;
@@ -223,9 +223,10 @@ class Format {
       ) + s.value(part.name)      
     ].join(', '), c, s, limit);
     
-  static public function insert<Row:{}>(table:TableInfo<Row>, rows:Array<Insert<Row>>, s:Sanitizer) {
+  static public function insert<Row:{}>(table:TableInfo<Row>, rows:Array<Insert<Row>>, s:Sanitizer, options:InsertOptions) {
+    var ignore = options != null && options.ignore;
     return
-      'INSERT INTO ${s.ident(table.getName())} (${[for (f in table.fieldnames()) s.ident(f)].join(", ")}) VALUES ' +
+      'INSERT ${ignore ? 'IGNORE' : ''} INTO ${s.ident(table.getName())} (${[for (f in table.fieldnames()) s.ident(f)].join(", ")}) VALUES ' +
          [for (row in rows) '(' + table.sqlizeRow(row, s.value).join(', ') + ')'].join(', ');
   }
   

--- a/src/tink/sql/Table.hx
+++ b/src/tink/sql/Table.hx
@@ -54,11 +54,11 @@ class TableSource<Fields, Filter:(Fields->Condition), Row:{}, Db>
   public function updateSchema(changes: Array<SchemaChange>)
     return cnx.updateSchema(this, changes);
   
-  public function insertMany(rows:Array<Insert<Row>>)
-    return rows.length == 0 ? Promise.NULL : cnx.insert(this, rows);
+  public function insertMany(rows:Array<Insert<Row>>, ?options)
+    return rows.length == 0 ? Promise.NULL : cnx.insert(this, rows, options);
     
-  public function insertOne(row:Insert<Row>)
-    return insertMany([row]);
+  public function insertOne(row:Insert<Row>, ?options)
+    return insertMany([row], options);
     
   public function update(f:Fields->Update<Row>, options:{ where: Filter, ?max:Int }) {
     return switch f(this.fields) {

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -85,8 +85,8 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
       return (res[0].count: Int)
     );
   
-  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>):Promise<Id<Row>> 
-    return query({sql: Format.insert(table, items, this)}).next(function(res)
+  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>, ?options):Promise<Id<Row>> 
+    return query({sql: Format.insert(table, items, this, options)}).next(function(res)
       return new Id(res.insertId)
     );
         

--- a/src/tink/sql/drivers/php/MySQLi.hx
+++ b/src/tink/sql/drivers/php/MySQLi.hx
@@ -76,8 +76,8 @@ class MySQLiConnection<Db:DatabaseInfo> implements Connection<Db> implements San
       return Std.parseInt(result.fetch_row()[0]);
     });
   
-  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>):Promise<Id<Row>>
-    return query(Format.insert(table, items, this)).next(function (_)
+  public function insert<Row:{}>(table:TableInfo<Row>, items:Array<Insert<Row>>, options):Promise<Id<Row>>
+    return query(Format.insert(table, items, this, options)).next(function (_)
       return new Id(cnx.insert_id)
     );
         

--- a/tests/FormatTest.hx
+++ b/tests/FormatTest.hx
@@ -28,6 +28,12 @@ class FormatTest extends TestWithDb {
 		return assert(Format.createTable(table, sanitizer) == sql);
 	}
 	
+	@:variant(true, 'INSERT IGNORE INTO `PostTags` (`post`, `tag`) VALUES (1, \'haxe\')')
+	@:variant(false, 'INSERT INTO `PostTags` (`post`, `tag`) VALUES (1, \'haxe\')')
+	public function insertIgnore(ignore, result) {
+		return assert(Format.insert(db.PostTags, [{post: 1, tag: 'haxe'}], sanitizer, {ignore: ignore}) == result);
+	}
+	
 	public function like() {
 		var dataset = db.Types.where(Types.text.like('mystring'));
 		return assert(Format.selectAll(@:privateAccess dataset.target, @:privateAccess dataset.condition, sanitizer) == 'SELECT * FROM `Types` WHERE (`Types`.`text` LIKE \'mystring\')');


### PR DESCRIPTION
This allows the `INSERT IGNORE` statement by specifying a option object in the insert call, e.g:

```haxe
db.table.insertMany([...], {ignore: true});
```