### PR TITLE
Define type aliases for fields and result

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,11 @@
         ["dev.hxml"]
     ],
     "editor.tabSize": 2,
-    "editor.insertSpaces": true
+    "editor.insertSpaces": true,
+    "haxe.executable": {
+        "path": "node_modules/.bin/haxe",
+        "windows": {
+            "path": "node_modules/.bin/haxe.cmd"
+        }
+    }
 }

--- a/src/tink/sql/Table.hx
+++ b/src/tink/sql/Table.hx
@@ -136,7 +136,7 @@ class TableSource<Fields, Filter:(Fields->Condition), Row:{}, Db>
           ).concat([TPType(e.pos.makeBlankType())])
         );
         var aliasFields = [];
-        switch fields {
+        switch haxe.macro.Context.follow(fields) {
           case TAnonymous(_.get().fields => originalFields):
             for (field in originalFields) 
               aliasFields.push({

--- a/src/tink/sql/macros/TableBuilder.hx
+++ b/src/tink/sql/macros/TableBuilder.hx
@@ -14,7 +14,6 @@ class TableBuilder {
       return
         switch ctx.type {
           case TAnonymous(_.get() => { fields: [{ kind: FVar(_, _), name: name, type: Context.followWithAbstracts(_)  => TAnonymous(_.get().fields => fields) }] } ):
-
             var cName = ctx.name;
             var names = [for (f in fields) f.name];
 
@@ -175,9 +174,25 @@ class TableBuilder {
                 }
               });
             }
-            var filterType = (macro function ($name:$fieldsType):tink.sql.Expr.Condition return tink.sql.Expr.ExprData.EValue(true, tink.sql.Expr.ValueType.VBool)).typeof().sure().toComplex({ direct: true });
 
-            macro class $cName<Db> extends tink.sql.Table.TableSource<$fieldsType, $filterType, $rowType, Db> {
+            var module = Context.getLocalModule().split('.');
+            module.pop();
+            function define(type, name) {
+              Context.defineType({
+                fields: [],
+                name: name,
+                pack: module,
+                pos: ctx.pos,
+                kind: TDAlias(type)
+              });
+              return module.concat([name]).join('.').asComplexType();
+            }
+            // Typedef fields and result so we get readable error messages
+            var fieldsAlias = define(fieldsType, '${name}_Fields');
+            var rowAlias = define(rowType, '${name}_Result');
+            var filterType = (macro function ($name:$fieldsAlias):tink.sql.Expr.Condition return tink.sql.Expr.ExprData.EValue(true, tink.sql.Expr.ValueType.VBool)).typeof().sure().toComplex({ direct: true });
+
+            macro class $cName<Db> extends tink.sql.Table.TableSource<$fieldsAlias, $filterType, $rowAlias, Db> {
 
               public function new(cnx, tableName, ?alias) {
                 super(cnx, new tink.sql.Table.TableName(tableName), alias, ${EObjectDecl(fieldsExprFields).at(ctx.pos)});


### PR DESCRIPTION
Fixes #62
Defines a typedef for fields as `${table}_Fields` and result as `${table}_Result`. Not sure if we want to do extra work here to avoid name collisions? The error messages work a lot better though (instead of something that is too long to paste here):
````
tests/FormatTest.hx:62: characters 16-58 : tink.sql.FilterableWhere<Types_Fields, Types : Types_Fields -> tink.sql.Condition, Types_Result, Db> has no field next
````