### PR TITLE
Remove Id's String cast

### DIFF
--- a/src/tink/sql/Types.hx
+++ b/src/tink/sql/Types.hx
@@ -30,10 +30,7 @@ abstract Id<T>(Int) to Int {
 
   public inline function new(v)
     this = v;
-
-  @:from static inline function ofStringly<T>(s:tink.Stringly):Id<T>
-    return new Id(s);
-
+  
   @:from static inline function ofInt<T>(i:Int):Id<T>
     return new Id(i);
 


### PR DESCRIPTION
This is mostly a trouble maker rather than a convenient function.

1. it subverts the type system (string is silently accepted without notice, mostly happen in refactors)
2. it crashes if the parsing is invalid

over the past few years I only get crashes from it but never really get any benefits.