### PR TITLE
Add a TRIM function to tink.sql.expr.Functions. 

### DIFF
--- a/src/tink/sql/expr/ExprTyper.hx
+++ b/src/tink/sql/expr/ExprTyper.hx
@@ -92,6 +92,7 @@ class ExprTyper {
       case EUnOp(Not | IsNull, _, _): Some(ValueType.VBool);
       case EUnOp((_: UnOp<Dynamic, Dynamic>) => Neg, _, _): Some(ValueType.VBool);
       case ECall('COUNT', _): Some(ValueType.VInt);
+      case ECall('TRIM', _): Some(ValueType.VString);
       case ECall('ST_Distance_Sphere', _): Some(ValueType.VFloat);
       case ECall('IF', [_, ifTrue, _]): type(ifTrue);
       case ECall(_, _): Some(ValueType.VBool);

--- a/src/tink/sql/expr/Functions.hx
+++ b/src/tink/sql/expr/Functions.hx
@@ -17,6 +17,9 @@ class Functions {
   public static function min<D,O>(e:Field<D,O>):Expr<D> 
     return ECall('MIN', cast [e]);
 
+  public static function trim<D,O>(e:Field<D,O>):Expr<String>
+    return ECall('TRIM', cast [e]);
+
   public static function stContains<T>(g1:Expr<Geometry>, g2:Expr<Geometry>):Expr<Bool>
     return ECall('ST_Contains', cast [g1, g2]);
 


### PR DESCRIPTION
The reason why is a little tricky, it is mainly to allow hacking an Int type to a String.

Where this gets useful is when we need to map an Int column to a String in a `.next()`.
E.g.

```haxe
// Without the TRIM:
db.Foo
  .select( {
     id    : Foo.id,
     b     : Foo.b,
     c     : Foo.c,
     d     : Foo.d,
     e     : Foo.e,
     f     : Foo.f
   })
   .first()
   .next( o -> {
       id: Std.string(id).map(s -> someTransformation(s)),
       name: name,
       b: b,
       c: c,
       d: d,
       e: e,
       f: f
    });

// By contrast if we had a TRIM function:
db.Foo
  .select( {
     ref   : Functions.trim(Foo.id),
     b     : Foo.b,
     c     : Foo.c,
     d     : Foo.d,
     e     : Foo.e,
     f     : Foo.f
   })
   .first()
   .next( o -> { o.ref = someTransformation(o.ref); o; });
```

As an additional benefit there is no creation of another object, because the Promised object
already types `ref` as a String.

Maybe TRIM is a weird choice here, I just didn't find a SQL function to convert to a String and only that. We could simply have a string function return an `Expr<String>` but at least TRIM is  a regular SQL function, even if people will think it is useless it is at least not too surprising.

There might be a better solution but I'm opening a PR now and we can discuss it.