### PR TITLE
Support streaming for SELECT queries (#113)

### DIFF
--- a/haxe_libraries/tink_core.hxml
+++ b/haxe_libraries/tink_core.hxml
@@ -1,3 +1,3 @@
--D tink_core=1.24.0
-# @install: lix --silent download "gh://github.com/haxetink/tink_core#a182e8c47e54b0587594010d435f8464379cc648" into tink_core/1.24.0/github/a182e8c47e54b0587594010d435f8464379cc648
--cp ${HAXE_LIBCACHE}/tink_core/1.24.0/github/a182e8c47e54b0587594010d435f8464379cc648/src
+# @install: lix --silent download "gh://github.com/haxetink/tink_core#d64de008ab41c5f4a85b7d6d0b31ffda705b8606" into tink_core/1.26.0/github/d64de008ab41c5f4a85b7d6d0b31ffda705b8606
+-cp ${HAXE_LIBCACHE}/tink_core/1.26.0/github/d64de008ab41c5f4a85b7d6d0b31ffda705b8606/src
+-D tink_core=1.26.0

--- a/haxe_libraries/tink_streams.hxml
+++ b/haxe_libraries/tink_streams.hxml
@@ -1,6 +1,6 @@
--D tink_streams=0.3.2
-# @install: lix --silent download "gh://github.com/haxetink/tink_streams#01a2b3894ae7ee5eb583503282371e307c03f065" into tink_streams/0.3.2/github/01a2b3894ae7ee5eb583503282371e307c03f065
+# @install: lix --silent download "gh://github.com/haxetink/tink_streams#a26e8338254bb6be8432eba37f954d1dd076a8c9" into tink_streams/0.3.3/github/a26e8338254bb6be8432eba37f954d1dd076a8c9
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_streams/0.3.2/github/01a2b3894ae7ee5eb583503282371e307c03f065/src
+-cp ${HAXE_LIBCACHE}/tink_streams/0.3.3/github/a26e8338254bb6be8432eba37f954d1dd076a8c9/src
+-D tink_streams=0.3.3
 # temp for development, delete this file when pure branch merged
 -D pure

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -127,7 +127,7 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
           cb(Failure(Error.ofJsError(err)));
         } else {
           var query = cnx.query(options);
-          var stream = Stream.ofNodeStream('query', query.stream(), {onEnd: cnx.release});
+          var stream = Stream.ofNodeStream('query', query.stream({highWaterMark: 1024}), {onEnd: cnx.release});
           cb(Success(stream));
         }
       });
@@ -193,7 +193,7 @@ extern class NativeConnection {
   function release():Void;
 }
 extern class NativeQuery<Row> extends EventEmitter<NativeQuery<Row>> {
-  function stream():NativeStream;
+  function stream(?opt:{?highWaterMark:Int}):NativeStream;
 }
 
 extern class NativeStream extends Readable<NativeStream> {}


### PR DESCRIPTION
Streaming query requires me to manually acquire a connection from the pool and release it after finished streaming. For consistency I also modified the non-streaming query to obtain/release a connection manually.