### PR TITLE
add ssl field to node driver settings

### DIFF
--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -5,6 +5,7 @@ import js.node.events.EventEmitter;
 import js.node.Buffer;
 import js.node.tls.SecureContext;
 import haxe.DynamicAccess;
+import haxe.extern.EitherType;
 import haxe.io.Bytes;
 import tink.sql.Query;
 import tink.sql.Info;
@@ -19,21 +20,10 @@ import #if haxe3 js.lib.Error #else js.Error #end as JsError;
 
 using tink.CoreApi;
 
-abstract SslSettings(Any) to Any {
-  @:from public static inline function ofString(s:String)
-    return new SslSettings(s);
-
-  @:from public static inline function ofSecureContextOptions(o:SecureContextOptions)
-    return new SslSettings(o);
-
-  inline function new(settings)
-    this = settings;
-}
-
 typedef NodeSettings = {
   > MySqlSettings,
   ?connectionLimit:Int,
-  ?ssl:SslSettings,
+  ?ssl:EitherType<String, SecureContextOptions>,
 }
 
 class MySql implements Driver {

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -3,6 +3,7 @@ package tink.sql.drivers.node;
 import js.node.stream.Readable.Readable;
 import js.node.events.EventEmitter;
 import js.node.Buffer;
+import js.node.tls.SecureContext;
 import haxe.DynamicAccess;
 import haxe.io.Bytes;
 import tink.sql.Query;
@@ -18,10 +19,21 @@ import #if haxe3 js.lib.Error #else js.Error #end as JsError;
 
 using tink.CoreApi;
 
+abstract SslSettings(Any) to Any {
+  @:from public static inline function ofString(s:String)
+    return new SslSettings(s);
+
+  @:from public static inline function ofSecureContextOptions(o:SecureContextOptions)
+    return new SslSettings(o);
+
+  inline function new(settings)
+    this = settings;
+}
+
 typedef NodeSettings = {
   > MySqlSettings,
   ?connectionLimit:Int,
-  ?ssl:Any,
+  ?ssl:SslSettings,
 }
 
 class MySql implements Driver {


### PR DESCRIPTION
To connect to a database in azure, SSL options might be required. Using an empty `ssl: {}` already did the trick for me and typing the whole node tls-options mentioned [here](https://github.com/mysqljs/mysql#ssl-options) felt like overkill for now so i went with `Any`.