### PR TITLE
fixing node mysql's timezone

### DIFF
--- a/src/tink/sql/drivers/MySql.hx
+++ b/src/tink/sql/drivers/MySql.hx
@@ -25,6 +25,7 @@ private class MySqlSanitizer implements Sanitizer {
     if (Std.is(v, Bool)) return v ? 'true' : 'false';
     if (v == null || Std.is(v, Int)) return '$v';
     if (Std.is(v, Bytes)) v = (cast v: Bytes).toString();
+    if (Std.is(v, Date)) return 'FROM_UNIXTIME(${(v:Date).getTime()/1000})';
     return string('$v');
   }
   

--- a/src/tink/sql/drivers/MySqlSettings.hx
+++ b/src/tink/sql/drivers/MySqlSettings.hx
@@ -4,6 +4,7 @@ typedef MySqlSettings = {
   @:optional var charset(default, null):String;
   @:optional var host(default, null):String;
   @:optional var port(default, null):Int;
+  @:optional var timezone(default, null):String;
   var user(default, null):String;
   var password(default, null):String;
 }

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -66,7 +66,10 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
   }
 
   public function value(v:Any):String
-    return NativeDriver.escape(if(Std.is(v, Bytes)) Buffer.hxFromBytes(v) else v);
+    return if (Std.is(v, Date))
+      'FROM_UNIXTIME(${(v:Date).getTime()/1000})';
+    else
+      NativeDriver.escape(if(Std.is(v, Bytes)) Buffer.hxFromBytes(v) else v);
 
   public function ident(s:String):String
     return NativeDriver.escapeId(s);

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -41,6 +41,7 @@ class MySql implements Driver {
       host: settings.host,
       port: settings.port,
       database: name,
+      timezone: settings.timezone,
       connectionLimit: settings.connectionLimit,
       charset: settings.charset,
       ssl: settings.ssl,


### PR DESCRIPTION
Doc: https://github.com/mysqljs/mysql#connection-options

> `timezone`: The timezone configured on the MySQL server. This is used to type cast server date/time values to JavaScript `Date` object and vice versa. This can be `'local'`, `'Z'`, or an offset in the form `+HH:MM` or `-HH:MM`. (Default: `'local'`)

If I understand correctly, node-mysql doesn't know about the server's timezone and its default value `local` just assumes the server is in the same timezone as the client... i.e. no timezone conversion.

I have a MySQL server in `Z` and my local machine is `+08:00`. I have to use `timezone: "Z"` during connection in order to get correct results.