### PR TITLE
Upsert support

### DIFF
--- a/src/tink/sql/Query.hx
+++ b/src/tink/sql/Query.hx
@@ -75,6 +75,7 @@ typedef InsertOperation<Db, Row:{}> = {
   data:InsertData<Db, Row>,
   ?ignore:Bool, // mysql only: INSERT IGNORE
   ?replace:Bool, // mysql only: REPLACE INTO
+  ?update:Update<Row>, // mysql only: ON DUPLICATE KEY UPDATE
 }
 
 enum InsertData<Db, Row:{}> {

--- a/src/tink/sql/Query.hx
+++ b/src/tink/sql/Query.hx
@@ -73,7 +73,7 @@ typedef DeleteOperation<Row:{}> = {
 typedef InsertOperation<Db, Row:{}> = {
   table:TableInfo,
   data:InsertData<Db, Row>,
-  ?ignore:Bool, // mysql: INSERT IGNORE, postgres: ON CONFLICT (primary key) DO NOTHING
+  ?ignore:Bool, // mysql: INSERT IGNORE, postgres: ON CONFLICT DO NOTHING
   ?replace:Bool, // mysql only: REPLACE INTO
   ?update:Update<Row>, // mysql: ON DUPLICATE KEY UPDATE, postgres: ON CONFLICT (primary key) DO UPDATE SET
 }

--- a/src/tink/sql/Query.hx
+++ b/src/tink/sql/Query.hx
@@ -75,7 +75,7 @@ typedef InsertOperation<Db, Row:{}> = {
   data:InsertData<Db, Row>,
   ?ignore:Bool, // mysql only: INSERT IGNORE
   ?replace:Bool, // mysql only: REPLACE INTO
-  ?update:Update<Row>, // mysql only: ON DUPLICATE KEY UPDATE
+  ?update:Update<Row>, // mysql: ON DUPLICATE KEY UPDATE, postgres: ON CONFLICT (primary key) DO UPDATE SET
 }
 
 enum InsertData<Db, Row:{}> {

--- a/src/tink/sql/Query.hx
+++ b/src/tink/sql/Query.hx
@@ -73,7 +73,7 @@ typedef DeleteOperation<Row:{}> = {
 typedef InsertOperation<Db, Row:{}> = {
   table:TableInfo,
   data:InsertData<Db, Row>,
-  ?ignore:Bool, // mysql only: INSERT IGNORE
+  ?ignore:Bool, // mysql: INSERT IGNORE, postgres: ON CONFLICT (primary key) DO NOTHING
   ?replace:Bool, // mysql only: REPLACE INTO
   ?update:Update<Row>, // mysql: ON DUPLICATE KEY UPDATE, postgres: ON CONFLICT (primary key) DO UPDATE SET
 }

--- a/src/tink/sql/Table.hx
+++ b/src/tink/sql/Table.hx
@@ -91,7 +91,7 @@ class TableSource<Fields, Filter:(Fields->Condition), Row:{}, Db>
       data: data, 
       ignore: options != null && !!options.ignore,
       replace: options != null && !!options.replace,
-      update: options != null ? options.update(this.fields) : null,
+      update: options != null && options.update != null ? options.update(this.fields) : null,
     }));
   }
 

--- a/src/tink/sql/Table.hx
+++ b/src/tink/sql/Table.hx
@@ -84,16 +84,17 @@ class TableSource<Fields, Filter:(Fields->Condition), Row:{}, Db>
     
   public function insertSelect(selected:Selected<Dynamic, Dynamic, Row, Db>, ?options): Promise<Id<Row>>
     return insert(Select(selected.toSelectOp()), options);
-      
-  function insert(data, ?options:{?ignore:Bool, ?replace:Bool}): Promise<Id<Row>> {
+
+  function insert(data, ?options:{?ignore:Bool, ?replace:Bool, ?update:Fields->Update<Row>}): Promise<Id<Row>> {
     return cnx.execute(Insert({
       table: info, 
       data: data, 
       ignore: options != null && !!options.ignore,
       replace: options != null && !!options.replace,
+      update: options != null ? options.update(this.fields) : null,
     }));
   }
-    
+
   public function update(f:Fields->Update<Row>, options:{ where: Filter, ?max:Int })
     return switch f(this.fields) {
       case []:

--- a/src/tink/sql/expr/Functions.hx
+++ b/src/tink/sql/expr/Functions.hx
@@ -37,4 +37,16 @@ class Functions {
 
   public static function exists(q:Dataset<Dynamic, Dynamic, Dynamic>):Condition
     return ECall('EXISTS ', cast [q.toExpr()], VBool, false);
+
+  /**
+   * MySQL:
+   * Refer to column values from the INSERT portion of the INSERT ... ON DUPLICATE KEY UPDATE statement.
+   * https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+   * 
+   * Postgres:
+   * Traslates to `EXCLUDED.$field`.
+   * https://www.postgresql.org/docs/current/sql-insert.html
+   */
+  public static function values<D,O>(e:Field<D,O>)
+    return ECall("VALUES", cast [e], VTypeOf(e), true);
 }

--- a/src/tink/sql/format/MySqlFormatter.hx
+++ b/src/tink/sql/format/MySqlFormatter.hx
@@ -128,6 +128,19 @@ class MySqlFormatter extends SqlFormatter<MysqlColumnInfo, MysqlKeyInfo> {
       .add('INTO');
   }
 
+  override function insert<Db, Row:{}>(insert:InsertOperation<Db, Row>) {
+    return insert.update == null ?
+      super.insert(insert) :
+      super.insert(insert)
+        .add('ON DUPLICATE KEY UPDATE')
+        .space()
+        .separated(insert.update.map(function (set) {
+          return ident(set.field.name)
+            .add('=')
+            .add(expr(set.expr, false));
+        }));
+  }
+
   override function expr(e:ExprData<Dynamic>, printTableName = true):Statement
     return switch e {
       case null:

--- a/src/tink/sql/format/PostgreSqlFormatter.hx
+++ b/src/tink/sql/format/PostgreSqlFormatter.hx
@@ -113,17 +113,15 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
         // pass
     }
 
-    var pKeys = SqlFormatter.getPrimaryKeys(insert.table);
     var statement = super.insert(insert);
 
     if (insert.ignore) {
       statement = statement
-        .add('ON CONFLICT')
-        .addParenthesis(separated(pKeys.map(k -> ident(k.name))))
-        .add('DO NOTHING');
+        .add('ON CONFLICT DO NOTHING');
     }
 
     if (insert.update != null) {
+      var pKeys = SqlFormatter.getPrimaryKeys(insert.table);
       statement = statement
         .add('ON CONFLICT')
         .addParenthesis(separated(pKeys.map(k -> ident(k.name))))

--- a/src/tink/sql/format/PostgreSqlFormatter.hx
+++ b/src/tink/sql/format/PostgreSqlFormatter.hx
@@ -105,22 +105,23 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
         // pass
     }
 
-    var p = SqlFormatter.getAutoIncPrimaryKeyCol(insert.table);
+    var pKeys = SqlFormatter.getPrimaryKeys(insert.table);
     var statement = super.insert(insert);
 
     if (insert.update != null) {
       statement = statement
         .add('ON CONFLICT')
-        .addParenthesis(p.name)
+        .addParenthesis(separated(pKeys.map(k -> ident(k.name))))
         .add('DO UPDATE SET')
         .space()
         .separated(insert.update.map(function (set) {
           return ident(set.field.name)
             .add('=')
-            .add(expr(set.expr, false));
+            .add(expr(set.expr, true));
         }));
     }
 
+    var p = SqlFormatter.getAutoIncPrimaryKeyCol(insert.table);
     if (p != null) {
       statement = statement.add(sql("RETURNING").addIdent(p.name));
     }

--- a/src/tink/sql/format/PostgreSqlFormatter.hx
+++ b/src/tink/sql/format/PostgreSqlFormatter.hx
@@ -88,21 +88,6 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
         super.defineColumn(column);
     }
 
-  static function getAutoIncPrimaryKeyCol(table:TableInfo) {
-    for (key in table.getKeys()) {
-      switch key {
-        case Primary([colName]): // is a single col primary key
-          var col = table.getColumns().find(col -> col.name == colName);
-          if (col.type.match(DInt(_, _, true))) { // is auto inc
-            return col;
-          }
-        default:
-          // pass
-      }
-    }
-    return null;
-  }
-
   static function isAutoInc(c:Column) {
     return c.type.match(DInt(_, _, true, _));
   }
@@ -120,7 +105,7 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
         // pass
     }
 
-    var p = getAutoIncPrimaryKeyCol(insert.table);
+    var p = SqlFormatter.getAutoIncPrimaryKeyCol(insert.table);
     var statement = super.insert(insert);
 
     if (insert.update != null) {

--- a/src/tink/sql/format/PostgreSqlFormatter.hx
+++ b/src/tink/sql/format/PostgreSqlFormatter.hx
@@ -108,6 +108,13 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
     var pKeys = SqlFormatter.getPrimaryKeys(insert.table);
     var statement = super.insert(insert);
 
+    if (insert.ignore) {
+      statement = statement
+        .add('ON CONFLICT')
+        .addParenthesis(separated(pKeys.map(k -> ident(k.name))))
+        .add('DO NOTHING');
+    }
+
     if (insert.update != null) {
       statement = statement
         .add('ON CONFLICT')

--- a/src/tink/sql/format/PostgreSqlFormatter.hx
+++ b/src/tink/sql/format/PostgreSqlFormatter.hx
@@ -68,6 +68,14 @@ class PostgreSqlFormatter extends SqlFormatter<PostgreSqlColumnInfo, PostgreSqlK
       // case EField(_, _, VGeometry(_)):
       //   super.expr(e, printTableName).concat(sql("::geometry"));
 
+      case ECall("VALUES", [e], type, parenthesis):
+        switch (e:ExprData<Dynamic>) {
+          case EField(_, name, type):
+            sql('EXCLUDED.').ident(name);
+          case _:
+            throw "assert";
+        }
+
       // the functions are named differently in postgis
       case ECall("ST_Distance_Sphere", args, type, parenthesis):
         super.expr(ECall("ST_DistanceSphere", args, type, parenthesis), printTableName);

--- a/src/tink/sql/format/SqlFormatter.hx
+++ b/src/tink/sql/format/SqlFormatter.hx
@@ -448,6 +448,19 @@ class SqlFormatter<ColInfo, KeyInfo> implements Formatter<ColInfo, KeyInfo> {
     }
     return null;
   }
+
+  static public function getPrimaryKeys(table:TableInfo) {
+    for (key in table.getKeys()) {
+      switch key {
+        case Primary(colNames):
+          var cols = table.getColumns();
+          return colNames.map(colName -> cols.find(col -> col.name == colName));
+        default:
+          // pass
+      }
+    }
+    return [];
+  }
 }
 
 typedef SqlType = {

--- a/src/tink/sql/format/SqlFormatter.hx
+++ b/src/tink/sql/format/SqlFormatter.hx
@@ -434,6 +434,20 @@ class SqlFormatter<ColInfo, KeyInfo> implements Formatter<ColInfo, KeyInfo> {
   public function parseKeys(keys:Array<KeyInfo>):Array<Key>
     throw 'implement';
 
+  static public function getAutoIncPrimaryKeyCol(table:TableInfo) {
+    for (key in table.getKeys()) {
+      switch key {
+        case Primary([colName]): // is a single col primary key
+          var col = table.getColumns().find(col -> col.name == colName);
+          if (col.type.match(DInt(_, _, true))) { // is auto inc
+            return col;
+          }
+        default:
+          // pass
+      }
+    }
+    return null;
+  }
 }
 
 typedef SqlType = {

--- a/tests/Db.hx
+++ b/tests/Db.hx
@@ -8,7 +8,6 @@ typedef User = {
   public var email(default, null):VarChar<50>;
   public var location(default, null):Null<VarChar<32>>;
 }
-
 typedef Post = {
   @:autoIncrement @:primary public var id(default, null):Id<Post>;
   public var author(default, null):Id<User>;
@@ -19,6 +18,12 @@ typedef Post = {
 typedef PostTags = {
   public var post(default, null):Id<Post>;
   public var tag(default, null):VarChar<50>;
+}
+
+typedef Clap = {
+  @:primary public var user(default, null):Id<User>;
+  @:primary public var post(default, null):Id<Post>;
+  public var count(default, null):Int;
 }
 
 typedef Types = {
@@ -109,7 +114,7 @@ typedef StringTypes = {
   public var textLong(default, null): LongText;
 }
 
-@:tables(User, Post, PostTags, Types, Geometry, Schema, StringTypes)
+@:tables(User, Post, PostTags, Clap, Types, Geometry, Schema, StringTypes)
 class Db extends tink.sql.Database {
   @:procedure var func:Int->{x:Int, point:tink.s2d.Point};
   @:table('alias') var PostAlias: Post;

--- a/tests/InsertIgnoreTest.hx
+++ b/tests/InsertIgnoreTest.hx
@@ -1,0 +1,97 @@
+package;
+
+import tink.unit.Assert.assert;
+import tink.sql.OrderBy;
+import Db;
+import tink.sql.Fields;
+import tink.sql.expr.Functions;
+import tink.sql.Types;
+
+using tink.CoreApi;
+
+@:asserts
+class InsertIgnoreTest extends TestWithDb {
+	var post:Id<Post>;
+
+	@:setup @:access(Run)
+	public function setup() {
+		var run = new Run(driver, db);
+		return Promise.inParallel([
+			db.User.create(),
+			db.Post.create(),
+			db.Clap.create(),
+		])
+			.next(function (_) return run.insertUsers())
+			.next(function (_) return db.User.where(r -> r.name == "Bob").first())
+			.next(function (bob) return db.Post.insertOne({
+				id: null,
+				title: "Bob's post",
+				author: bob.id,
+				content: 'A wonderful post by Bob',
+			}))
+			.next(function (post) return this.post = post);
+	}
+	
+	@:teardown
+	public function teardown() {
+		return Promise.inParallel([
+			db.User.drop(),
+			db.Post.drop(),
+			db.Clap.drop(),
+		]);
+	}
+	
+	public function insert()
+		return db.User.where(r -> r.name == "Alice")
+			.first()
+			.next(currentAlice -> {
+				db.User.insertOne({
+					id: currentAlice.id,
+					name: "Alice 2",
+					email: currentAlice.email,
+					location: currentAlice.location
+				}, {
+					ignore: true,
+				}).next(_ -> {
+					db.User.where(r -> r.name == "Alice").all();
+				}).next(alices -> {
+          asserts.assert(alices.length == 1);
+					asserts.assert(alices[0].id == currentAlice.id);
+					asserts.assert(alices[0].name == "Alice");
+					asserts.done();
+				});
+			});
+
+	public function compositePrimaryKey() {
+		return db.User.where(r -> r.name == "Christa").first()
+			.next(christa ->
+				db.Clap.insertOne({
+					user: christa.id,
+					post: post,
+					count: 1,
+				})
+					.next(_ ->
+						db.Clap
+							.where(r -> r.user == christa.id && r.post == post)
+							.first()
+					)
+					.next(clap -> asserts.assert(clap.count == 1))
+					.next(_ ->
+						db.Clap.insertOne({
+							user: christa.id,
+							post: post,
+							count: 1,
+						}, {
+							ignore: true
+						})
+					)
+					.next(_ ->
+						db.Clap
+							.where(r -> r.user == christa.id && r.post == post)
+							.first()
+					)
+					.next(clap -> asserts.assert(clap.count == 1))
+			)
+			.next(_ -> asserts.done());
+	}
+}

--- a/tests/OnDuplicateKeyTest.hx
+++ b/tests/OnDuplicateKeyTest.hx
@@ -1,0 +1,49 @@
+package;
+
+import tink.unit.Assert.assert;
+import tink.sql.OrderBy;
+import Db;
+import tink.sql.Fields;
+import tink.sql.expr.Functions;
+
+using tink.CoreApi;
+
+@:asserts
+class OnDuplicateKeyTest extends TestWithDb {
+	@:setup @:access(Run)
+	public function setup() {
+		var run = new Run(driver, db);
+		return Promise.inParallel([
+			db.User.create(),
+		])
+		.next(function (_) return run.insertUsers());
+	}
+	
+	@:teardown
+	public function teardown() {
+		return Promise.inParallel([
+			db.User.drop(),
+		]);
+	}
+	
+	public function insert()
+		return db.User.where(r -> r.name == "Alice")
+			.first()
+			.next(currentAlice -> {
+				trace(currentAlice);
+				db.User.insertOne({
+					id: currentAlice.id,
+					name: currentAlice.name,
+					email: currentAlice.email,
+					location: currentAlice.location
+				}, {
+					update: u -> [u.name.set('Alice 2')],
+				}).next(newAliceId -> {
+					db.User.where(r -> r.id == newAliceId).first();
+				}).next(newAlice -> {
+					assert(newAlice.id == currentAlice.id);
+					assert(newAlice.name == "Alice 2");
+				});
+			});
+
+}

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -60,6 +60,7 @@ class Run extends TestWithDb {
       new ExprTest(postgres, dbPostgres),
       new Run(postgres, dbPostgres),
       new GeometryTest(postgres, dbPostgres),
+      new OnDuplicateKeyTest(postgres, dbPostgres),
       #end
 
       new TypeTest(sqlite, dbSqlite),

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -51,6 +51,7 @@ class Run extends TestWithDb {
       #if nodejs
       new ProcedureTest(mysql, dbMysql),
       #end
+      new OnDuplicateKeyTest(mysql, dbMysql),
 
       #if nodejs
       new TypeTest(postgres, dbPostgres),

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -51,7 +51,7 @@ class Run extends TestWithDb {
       #if nodejs
       new ProcedureTest(mysql, dbMysql),
       #end
-      new OnDuplicateKeyTest(mysql, dbMysql),
+      new UpsertTest(mysql, dbMysql),
 
       #if nodejs
       new TypeTest(postgres, dbPostgres),
@@ -60,7 +60,7 @@ class Run extends TestWithDb {
       new ExprTest(postgres, dbPostgres),
       new Run(postgres, dbPostgres),
       new GeometryTest(postgres, dbPostgres),
-      new OnDuplicateKeyTest(postgres, dbPostgres),
+      new UpsertTest(postgres, dbPostgres),
       #end
 
       new TypeTest(sqlite, dbSqlite),

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -51,6 +51,7 @@ class Run extends TestWithDb {
       #if nodejs
       new ProcedureTest(mysql, dbMysql),
       #end
+      new InsertIgnoreTest(mysql, dbMysql),
       new UpsertTest(mysql, dbMysql),
 
       #if nodejs
@@ -60,6 +61,7 @@ class Run extends TestWithDb {
       new ExprTest(postgres, dbPostgres),
       new Run(postgres, dbPostgres),
       new GeometryTest(postgres, dbPostgres),
+      new InsertIgnoreTest(postgres, dbPostgres),
       new UpsertTest(postgres, dbPostgres),
       #end
 

--- a/tests/Run.hx
+++ b/tests/Run.hx
@@ -119,7 +119,7 @@ class Run extends TestWithDb {
 
   public function info() {
     asserts.assert(db.name == 'test');
-    asserts.assert(sorted(db.tableNames()).join(',') == 'Geometry,Post,PostTags,Schema,StringTypes,Types,User,alias');
+    asserts.assert(sorted(db.tableNames()).join(',') == 'Clap,Geometry,Post,PostTags,Schema,StringTypes,Types,User,alias');
     asserts.assert(sorted(db.tableInfo('Post').columnNames()).join(',') == 'author,content,id,title');
     return asserts.done();
   }

--- a/tests/UpsertTest.hx
+++ b/tests/UpsertTest.hx
@@ -5,24 +5,39 @@ import tink.sql.OrderBy;
 import Db;
 import tink.sql.Fields;
 import tink.sql.expr.Functions;
+import tink.sql.Types;
 
 using tink.CoreApi;
 
 @:asserts
 class UpsertTest extends TestWithDb {
+	var post:Id<Post>;
+
 	@:setup @:access(Run)
 	public function setup() {
 		var run = new Run(driver, db);
 		return Promise.inParallel([
 			db.User.create(),
+			db.Post.create(),
+			db.Clap.create(),
 		])
-		.next(function (_) return run.insertUsers());
+			.next(function (_) return run.insertUsers())
+			.next(function (_) return db.User.where(r -> r.name == "Bob").first())
+			.next(function (bob) return db.Post.insertOne({
+				id: null,
+				title: "Bob's post",
+				author: bob.id,
+				content: 'A wonderful post by Bob',
+			}))
+			.next(function (post) return this.post = post);
 	}
 	
 	@:teardown
 	public function teardown() {
 		return Promise.inParallel([
 			db.User.drop(),
+			db.Post.drop(),
+			db.Clap.drop(),
 		]);
 	}
 	
@@ -40,9 +55,44 @@ class UpsertTest extends TestWithDb {
 				}).next(newAliceId -> {
 					db.User.where(r -> r.id == newAliceId).first();
 				}).next(newAlice -> {
-					assert(newAlice.id == currentAlice.id);
-					assert(newAlice.name == "Alice 2");
+					asserts.assert(newAlice.id == currentAlice.id);
+					asserts.assert(newAlice.name == "Alice 2");
+					asserts.done();
 				});
 			});
 
+	public function compositePrimaryKey() {
+		return db.User.where(r -> r.name == "Christa").first()
+			.next(christa ->
+				db.Clap.insertOne({
+					user: christa.id,
+					post: post,
+					count: 1,
+				})
+					.next(_ ->
+						db.Clap
+							.where(r -> r.user == christa.id && r.post == post)
+							.first()
+					)
+					.next(clap -> asserts.assert(clap.count == 1))
+					.next(_ ->
+						db.Clap.insertOne({
+							user: christa.id,
+							post: post,
+							count: 1,
+						}, {
+							update: f -> [
+								f.count.set(f.count + 1),
+							]
+						})
+					)
+					.next(_ ->
+						db.Clap
+							.where(r -> r.user == christa.id && r.post == post)
+							.first()
+					)
+					.next(clap -> asserts.assert(clap.count == 2))
+			)
+			.next(_ -> asserts.done());
+	}
 }

--- a/tests/UpsertTest.hx
+++ b/tests/UpsertTest.hx
@@ -40,8 +40,8 @@ class UpsertTest extends TestWithDb {
 			db.Clap.drop(),
 		]);
 	}
-	
-	public function insert()
+
+	public function insertSimple()
 		return db.User.where(r -> r.name == "Alice")
 			.first()
 			.next(currentAlice -> {
@@ -60,6 +60,27 @@ class UpsertTest extends TestWithDb {
 					asserts.done();
 				});
 			});
+
+	public function insertValue() {
+		var newEmail = "bob@gmail.com";
+		return db.User.where(r -> r.name == "Bob")
+			.first()
+			.next(bob -> {
+				db.User.insertOne({
+					id: bob.id,
+					name: bob.name,
+					email: newEmail,
+					location: bob.location
+				}, {
+					update: u -> [u.email.set(Functions.values(u.email))],
+				}).next(_ -> {
+					db.User.where(r -> r.id == bob.id).first();
+				}).next(bob -> {
+					asserts.assert(bob.email == newEmail);
+					asserts.done();
+				});
+			});
+	}
 
 	public function compositePrimaryKey() {
 		return db.User.where(r -> r.name == "Christa").first()

--- a/tests/UpsertTest.hx
+++ b/tests/UpsertTest.hx
@@ -9,7 +9,7 @@ import tink.sql.expr.Functions;
 using tink.CoreApi;
 
 @:asserts
-class OnDuplicateKeyTest extends TestWithDb {
+class UpsertTest extends TestWithDb {
 	@:setup @:access(Run)
 	public function setup() {
 		var run = new Run(driver, db);

--- a/tests/UpsertTest.hx
+++ b/tests/UpsertTest.hx
@@ -30,7 +30,6 @@ class UpsertTest extends TestWithDb {
 		return db.User.where(r -> r.name == "Alice")
 			.first()
 			.next(currentAlice -> {
-				trace(currentAlice);
 				db.User.insertOne({
 					id: currentAlice.id,
 					name: currentAlice.name,


### PR DESCRIPTION
Added an `update` param to `insert()`'s `options`.
See tests/UpsertTest.hx for usage example.

For MySQL, it translates to `ON DUPLICATE KEY UPDATE`.
For Postgres, it translates to `ON CONFLICT (primary key) DO UPDATE SET`.
SQLite support needs [`RETURNING`](https://sqlite.org/lang_returning.html), which was added in SQLite 3.35.0 (2021-03-12). Let's keep it unsupported until at least node-sqlite3 updated to that version (https://github.com/mapbox/node-sqlite3/pull/1476).
