### PR TITLE
Add the `TRUNCATE TABLE` operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ var db = new Db('db_name', driver);
  - Table setup
     - `db.User.create(): Promise<Noise>;`
     - `db.User.drop(): Promise<Noise>;`
+    - `db.User.truncate(): Promise<Noise>;`
  - Selecting
     - `db.User.count(): Promise<Int>;`
     - `db.User.all(limit, orderBy): Promise<Array<User>>;`

--- a/src/tink/sql/Query.hx
+++ b/src/tink/sql/Query.hx
@@ -17,6 +17,7 @@ enum Query<Db, Result> {
   CallProcedure<Row:{}>(call:CallOperation<Row>):Query<Db, RealStream<Row>>;
   CreateTable<Row:{}>(table:TableInfo, ?ifNotExists:Bool):Query<Db, Promise<Noise>>;
   DropTable<Row:{}>(table:TableInfo):Query<Db, Promise<Noise>>;
+  TruncateTable<Row:{}>(table:TableInfo):Query<Db, Promise<Noise>>;
   AlterTable<Row:{}>(table:TableInfo, changes:Array<AlterTableOperation>):Query<Db, Promise<Noise>>;
   ShowColumns<Row:{}>(from:TableInfo):Query<Db, Promise<Array<Column>>>;
   ShowIndex<Row:{}>(from:TableInfo):Query<Db, Promise<Array<Key>>>;

--- a/src/tink/sql/Table.hx
+++ b/src/tink/sql/Table.hx
@@ -49,6 +49,9 @@ class TableSource<Fields, Filter:(Fields->Condition), Row:{}, Db>
   public function drop()
     return cnx.execute(DropTable(info));
 
+  public function truncate()
+    return cnx.execute(TruncateTable(info));
+
   public function diffSchema(destructive = false) {
     var schema = new Schema(info.getColumns(), info.getKeys());
     return (cnx.execute(ShowColumns(info)) && cnx.execute(ShowIndex(info)))

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -98,7 +98,7 @@ class MySqlConnection<Db:DatabaseInfo> implements Connection<Db> implements Sani
             next: function () return parse(iterator.next())
           });
         }));
-      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _):
+      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _) | TruncateTable(_):
         fetch().next(function(_) return Noise);
       case Insert(_):
         fetch().next(function(res) return new Id(res.insertId));

--- a/src/tink/sql/drivers/node/PostgreSql.hx
+++ b/src/tink/sql/drivers/node/PostgreSql.hx
@@ -144,7 +144,7 @@ class PostgreSqlConnection<Db:DatabaseInfo> implements Connection<Db> implements
         fetch().next(function(res) return {rowsAffected: res.rowCount});
       case Delete(_):
         fetch().next(function(res) return {rowsAffected: res.rowCount});
-      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _):
+      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _) | TruncateTable(_):
         fetch().next(function(r) {
           return Noise;
         });

--- a/src/tink/sql/drivers/node/Sqlite3.hx
+++ b/src/tink/sql/drivers/node/Sqlite3.hx
@@ -81,6 +81,9 @@ class Sqlite3Connection<Db:DatabaseInfo> implements Connection<Db> {
         });
       case CreateTable(_, _) | DropTable(_) | AlterTable(_, _):
         run(query).next(function(_) return Noise);
+      case TruncateTable(table):
+        // https://sqlite.org/lang_delete.html#the_truncate_optimization
+        run(Delete({from: table})).next(function(_) return Noise);
       case Insert(_):
         run(query).next(function(res) return new Id(res.lastID));
       case Update(_) | Delete(_):

--- a/src/tink/sql/drivers/php/PDO.hx
+++ b/src/tink/sql/drivers/php/PDO.hx
@@ -112,7 +112,7 @@ class PDOConnection<Db:DatabaseInfo> implements Connection<Db> implements Saniti
             next: function () return parse(row)
           });
         }));
-      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _):
+      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _) | TruncateTable(_):
         fetch().next(function(_) return Noise);
       case Insert(_):
         fetch().next(function(_) return new Id(Std.parseInt(cnx.lastInsertId())));

--- a/src/tink/sql/drivers/sys/StdConnection.hx
+++ b/src/tink/sql/drivers/sys/StdConnection.hx
@@ -42,7 +42,7 @@ class StdConnection<Db:DatabaseInfo> implements Connection<Db> {
             next: function () return parse(res.next())
           });
         }));
-      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _):
+      case CreateTable(_, _) | DropTable(_) | AlterTable(_, _) | TruncateTable(_):
         fetch().next(function(_) return Noise);
       case Insert(_):
         fetch().next(function(_) return new Id(cnx.lastInsertId()));

--- a/src/tink/sql/format/SqlFormatter.hx
+++ b/src/tink/sql/format/SqlFormatter.hx
@@ -21,6 +21,7 @@ class SqlFormatter<ColInfo, KeyInfo> implements Formatter<ColInfo, KeyInfo> {
     return switch query {
       case CreateTable(table, ifNotExists): createTable(table, ifNotExists);
       case DropTable(table): dropTable(table);
+      case TruncateTable(table): truncateTable(table);
       case Insert(op): insert(op);
       case Select(op): select(op);
       case Union(op): union(op);
@@ -123,6 +124,9 @@ class SqlFormatter<ColInfo, KeyInfo> implements Formatter<ColInfo, KeyInfo> {
 
   function dropTable(table:TableInfo)
     return sql('DROP TABLE').addIdent(table.getName());
+
+  function truncateTable(table:TableInfo)
+    return sql('TRUNCATE TABLE').addIdent(table.getName());
 
   function insertRow(columns:Iterable<Column>, row:DynamicAccess<Any>):Statement
     return parenthesis(


### PR DESCRIPTION
Fixes #132

Note that SQLite needs a special treatment because it doesn't support the `TRUNCATE` statement. We can emulate it by using a `DELETE` statement (cf. https://sqlite.org/lang_delete.html#the_truncate_optimization).

**This PR addresses this case only in the Node.js driver.** I didn't want to make any big changes because I'm not familiar enough with the Tink SQL code yet... and someone using SQLite should propably know that `TRUNCATE` is not supported.