### PR TITLE
Add a `mysql_session_timezone` define to disable MySQL date functions

### DIFF
--- a/src/tink/sql/drivers/MySql.hx
+++ b/src/tink/sql/drivers/MySql.hx
@@ -29,7 +29,11 @@ private class MySqlSanitizer implements Sanitizer {
     if (Std.is(v, Bool)) return v ? 'true' : 'false';
     if (v == null || Std.is(v, Int)) return '$v';
     if (Std.is(v, Bytes)) v = (cast v: Bytes).toString();
-    if (Std.is(v, Date)) return 'DATE_ADD(FROM_UNIXTIME(0), INTERVAL ${(v:Date).getTime()/1000} SECOND)';
+
+    if (Std.is(v, Date)) return
+      #if mysql_session_timezone string((v: Date).toString())
+      #else 'DATE_ADD(FROM_UNIXTIME(0), INTERVAL ${(v: Date).getTime() / 1000} SECOND)' #end;
+
     return string('$v');
   }
   

--- a/src/tink/sql/drivers/node/MySql.hx
+++ b/src/tink/sql/drivers/node/MySql.hx
@@ -137,8 +137,9 @@ class MySqlConnection<Db> implements Connection<Db> implements Sanitizer {
   }
 
   public function value(v:Any):String {
-    if (Std.is(v, Date))
-      return 'DATE_ADD(FROM_UNIXTIME(0), INTERVAL ${(v : Date).getTime() / 1000} SECOND)';
+    if (Std.is(v, Date)) return
+      #if mysql_session_timezone NativeDriver.escape((v: Date).toString())
+      #else 'DATE_ADD(FROM_UNIXTIME(0), INTERVAL ${(v: Date).getTime() / 1000} SECOND)' #end;
 
     if (Int64.isInt64(v))
       return Int64.toStr(v);


### PR DESCRIPTION
The problem: the Node.js driver for MySQL uses the `DATE_ADD` function to handle `Date` values. But MySQL date functions don't correctly handle [daylight saving time](https://en.wikipedia.org/wiki/Daylight_saving_time).

Currently, on my servers using the `Europe/Paris` time zone, the queries generated give incorrect results:

```sql
SELECT UNIX_TIMESTAMP('2023-10-25 00:00:00');
-- 1698184800, same as: Date.fromString('2023-10-25 00:00:00').getTime() / 1000

SELECT DATE_ADD(FROM_UNIXTIME(0), INTERVAL 1698184800 SECOND);
-- 2023-10-24 23:00:00 !!!
```

This issue does not occur with the PHP/PDO driver which converts dates to `yyyy-mm-dd hh:hh:ss` strings.
https://github.com/haxetink/tink_sql/blob/master/src/tink/sql/drivers/php/PDO.hx#L86

This PR adds a `mysql_session_timezone` define to disable the use of MySQL date functions in the Node.js driver, bringing it into line with the PDO driver.